### PR TITLE
equity prices

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ client.disconnect();
 | `rfq`                     | `quote_expired`    | -        | -                                                               | [`Quote`](#quote)                   |                                                             |
 | `crypto_prices`           | `update`           | -        | `{"symbol":string}`                                             | [`CryptoPrice`](#cryptoprice)       | [`CryptoPriceHistorical`](#initial-data-dump-on-connection) |
 | `crypto_prices_chainlink` | `update`           | -        | `{"symbol":string}`                                             | [`CryptoPrice`](#cryptoprice)       | [`CryptoPriceHistorical`](#initial-data-dump-on-connection) |
+| `equity_prices` | `update`           | -        | `{"symbol":string}`                                             | [`EquityPrice`](#equityprice)       | [`EquityPriceHistorical`](#initial-data-dump-on-connection) |
 | `clob_user`               | `order`            | ClobAuth | -                                                               | [`Order`](#order)                   |                                                             |
 | `clob_user`               | `trade`            | ClobAuth | -                                                               | [`Trade`](#trade-1)                 |                                                             |
 | `clob_market`             | `price_change`     | -        | `["100","200",...]` (filters are mandatory on this one)         | [`PriceChanges`](#pricechanges)     |                                                             |
@@ -245,14 +246,38 @@ client.subscribe({
 
 #### Filters
 
-- `{"symbol":"btcusdt"}`
-- `{"symbol":"ethusdt"}`
-- `{"symbol":"xrpusdt"}`
-- `{"symbol":"solusdt"}`
+- `{"symbol":"BTCUSDT"}`
+- `{"symbol":"ETHUSDT"}`
+- `{"symbol":"XRPUSDT"}`
+- `{"symbol":"SOLUSDT"}`
+- `{"symbol":"DOGEUSDT"}`
+
+### EquityPrice
+
+| Name        | Type   | Description                              |
+| ----------- | ------ | ---------------------------------------- |
+| `symbol`    | string | Symbol of the asset                      |
+| `timestamp` | number | Timestamp in milliseconds for the update |
+| `value`     | number | Value at the time of update              |
+
+#### Filters
+
+- `{"symbol":"AAPL"}`
+- `{"symbol":"TSLA"}`
+- `{"symbol":"MSFT"}`
+- `{"symbol":"GOOGL"}`
+- `{"symbol":"AMZN"}`
+- `{"symbol":"META"}`
+- `{"symbol":"NVDA"}`
+- `{"symbol":"NFLX"}`
+- `{"symbol":"PLTR"}`
+- `{"symbol":"OPEN"}`
+- `{"symbol":"RKLB"}`
+- `{"symbol":"ABNB"}`
 
 #### Initial data dump on connection
 
-When the connection is stablished, if a `filter` is used, the server will dump an initial snapshoot of recent data
+When the connection is stablished, if a `filter` is used, the server will dump an initial snapshoot of recent data. This applies to both CrytoPrice and EquityPrice.
 
 | Name   | Type   | Description                                                      |
 | ------ | ------ | ---------------------------------------------------------------- |

--- a/examples/quick-connection.ts
+++ b/examples/quick-connection.ts
@@ -50,6 +50,13 @@ const onConnect = (client: RealTimeDataClient): void => {
                 filters: "", // filters: `{"symbol":"eth/usd"}`,
             },
 
+            // equity_prices
+            {
+                topic: "equity_prices",
+                type: "*",
+                filters: "", // filters: `{"symbol":"AAPL"}`,
+            },
+
             // clob_market
             {
                 topic: "clob_market",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@polymarket/real-time-data-client",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "description": "A TypeScript client to receive real time data messages",
     "contributors": [
         {


### PR DESCRIPTION
- Updated examples
- Version bump

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Document `equity_prices` stream with schema/filters, add example subscription, expand crypto filter examples, and bump version to 1.4.2.
> 
> - **Docs (`README.md`)**:
>   - Add `equity_prices` topic with `EquityPrice` schema and filter examples; note historical data dump applies to both `CryptoPrice` and `EquityPrice`.
>   - Add additional `crypto_prices` filter examples with uppercase symbols.
> - **Examples**:
>   - Update `examples/quick-connection.ts` to include an `equity_prices` subscription example.
> - **Release**:
>   - Bump package version to `1.4.2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1744ee2f9ef691655254cc68ea38aa66929ffbfa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->