### PR TITLE
Fix WebSocket ping/pong to use protocol frames instead of text messages

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -93,7 +93,9 @@ export class RealTimeDataClient {
             this.ws.onmessage = this.onMessage;
             this.ws.onclose = this.onClose;
             this.ws.onerror = this.onError;
-            this.ws.pong = this.onPong;
+            if (this.ws.on) {
+                this.ws.on('pong', this.onPong);
+            }
         }
         return this;
     }
@@ -147,8 +149,8 @@ export class RealTimeDataClient {
         if (this.ws.readyState !== WebSocket.OPEN) {
             return console.warn("Socket not open. Ready state is:", this.ws.readyState);
         }
-
-        this.ws.send("ping", (err: Error | undefined) => {
+        
+        this.ws.ping((err: Error | undefined) => {
             if (err) {
                 console.error("ping error", err);
             }


### PR DESCRIPTION
Changed the WebSocket ping/pong implementation to use proper WebSocket protocol frames rather than sending text "ping"/"pong" messages. The server was responding to WebSocket protocol pings, not text messages, causing the previous implementation to fail silently.

Changes:
- Replaced `this.ws.send("ping")` with `this.ws.ping()` to send protocol-level ping frames
- Updated pong listener from `this.ws.pong` assignment to proper event listener `this.ws.on('pong', this.onPong)` for the 'ws' library
- Added conditional check for `this.ws.on` method availability before attaching pong listener to ensure compatibility

This ensures the client correctly implements the WebSocket ping/pong heartbeat mechanism as defined in RFC 6455, allowing proper connection health monitoring.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches the client to protocol-level ping/pong with a guarded 'pong' event listener for compatibility with the ws library.
> 
> - **Client WebSocket heartbeat (`src/client.ts`)**:
>   - Replace text-based `this.ws.send("ping")` with protocol-level `this.ws.ping(...)`.
>   - Attach pong handler via `this.ws.on('pong', this.onPong)` (only if `on` exists); remove direct `this.ws.pong` assignment.
>   - Maintain ping cycle: start on open and continue on pong.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04ada4a9f3c264f0d80c5a6eb810cfc1b4c38cb6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->