### PR TITLE
docs: reflect README example on renewed onMessage callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Here is a quick example about how to connect to the service and start receiving 
 import { RealTimeDataClient } from "../src/client";
 import { Message } from "../src/model";
 
-const onMessage = (message: Message): void => {
+const onMessage = (client: RealTimeDataClient, message: Message): void => {
     console.log(message.topic, message.type, message.payload);
 };
 


### PR DESCRIPTION
In https://github.com/Polymarket/real-time-data-client/commit/c899683b4b5c3d78e8015aba4d5aaacbe42f33a5 a client parameter was added to the `onMessage` callback function. This had not been reflected in the README.