### PR TITLE
fix: replace falsy check with nullish coalescing for autoReconnect

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -76,7 +76,7 @@ export class RealTimeDataClient {
     constructor(args?: RealTimeDataClientArgs) {
         this.host = args!.host || DEFAULT_HOST;
         this.pingInterval = args!.pingInterval || DEFAULT_PING_INTERVAL;
-        this.autoReconnect = args!.autoReconnect || true;
+        this.autoReconnect = args!.autoReconnect ?? true;
         this.onCustomMessage = args!.onMessage;
         this.onConnect = args!.onConnect;
         this.onStatusChange = args!.onStatusChange;


### PR DESCRIPTION
The previous implementation prevented setting autoReconnect to false, as the false value was treated as falsy and always defaulted to true.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fix defaulting logic for reconnection flag**
> 
> - In `src/client.ts`, updates constructor to use `args!.autoReconnect ?? true` so `autoReconnect=false` is respected instead of being overridden by a falsy check.
> 
> This ensures explicit `false` no longer defaults to `true`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dbe92e1e71b46f0e8126b8d93c70d761e81c0b7f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->