### PR TITLE
fix: respect explicit false for autoReconnect

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -76,7 +76,7 @@ export class RealTimeDataClient {
     constructor(args?: RealTimeDataClientArgs) {
         this.host = args!.host || DEFAULT_HOST;
         this.pingInterval = args!.pingInterval || DEFAULT_PING_INTERVAL;
-        this.autoReconnect = args!.autoReconnect || true;
+        this.autoReconnect = args!.autoReconnect ?? true;
         this.onCustomMessage = args!.onMessage;
         this.onConnect = args!.onConnect;
         this.onStatusChange = args!.onStatusChange;


### PR DESCRIPTION
  ## Change
Previously, autoReconnect used || true, which forced the value to true when false was passed explicitly.
  This change switches to nullish coalescing (?? true) so only null/undefined fall back to the default.
  - Updated autoReconnect initialization in src/client.ts:
      - from: args!.autoReconnect || true
      - to: args!.autoReconnect ?? true


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line defaulting logic change with limited blast radius; behavior only changes for callers passing `autoReconnect: false`.
> 
> **Overview**
> Updates `RealTimeDataClient` construction to default `autoReconnect` to `true` *only when unset* by switching from `|| true` to nullish coalescing (`?? true`), ensuring an explicitly provided `false` disables reconnection as intended.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc2bc8b7232c367056136192ac5970220b51cae2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->