### PR TITLE
Fixed heap out of memory on network issues

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -122,6 +122,11 @@ export class RealTimeDataClient {
      */
     private onError = async (err: ErrorEvent) => {
         console.error("error", err);
+        if (this.ws) {
+            this.ws.removeAllListeners();
+            this.ws.terminate();
+            this.ws = null;
+        }
         if (this.autoReconnect) {
             this.connect();
         }
@@ -134,6 +139,11 @@ export class RealTimeDataClient {
      */
     private onClose = async (message: CloseEvent) => {
         console.error("disconnected", "code", message.code, "reason", message.reason);
+        if (this.ws) {
+            this.ws.removeAllListeners();
+            this.ws.terminate();
+            this.ws = null;
+        }
         this.notifyStatusChange(ConnectionStatus.DISCONNECTED);
         if (this.autoReconnect) {
             this.connect();

--- a/src/client.ts
+++ b/src/client.ts
@@ -188,7 +188,7 @@ export class RealTimeDataClient {
      */
     public disconnect() {
         this.autoReconnect = false;
-        this.ws.close();
+        if(!!this.ws) this.ws.close();
     }
 
     /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -196,6 +196,9 @@ export class RealTimeDataClient {
      * @param msg Subscription request message.
      */
     public subscribe(msg: SubscriptionMessage) {
+        if (!this.ws) {
+            return console.warn("Socket not exists")
+        }
         if (this.ws.readyState !== WebSocket.OPEN) {
             return console.warn("Socket not open. Ready state is:", this.ws.readyState);
         }
@@ -212,6 +215,9 @@ export class RealTimeDataClient {
      * @param msg Unsubscription request message.
      */
     public unsubscribe(msg: SubscriptionMessage) {
+        if (!this.ws) {
+            return console.warn("Socket not exists")
+        }
         if (this.ws.readyState !== WebSocket.OPEN) {
             return console.warn("Socket not open. Ready state is:", this.ws.readyState);
         }

--- a/src/client.ts
+++ b/src/client.ts
@@ -113,14 +113,15 @@ export class RealTimeDataClient {
      * Handles WebSocket 'pong' event. Continues the ping cycle.
      */
     private onPong = async () => {
-        delay(this.pingInterval).then(() => this.ping());
+        if(this.ws) delay(this.pingInterval).then(() => this.ping());
     };
 
     /**
      * Handles WebSocket errors. Logs the error and attempts reconnection if `autoReconnect` is enabled.
      * @param err Error object describing the issue.
      */
-    private onError = async (err: ErrorEvent) => {
+    private onError = async (err: ErrorEvent) => {        
+        this.notifyStatusChange(ConnectionStatus.DISCONNECTED);
         console.error("error", err);
         if (this.ws) {
             this.ws.removeAllListeners();
@@ -154,15 +155,17 @@ export class RealTimeDataClient {
      * Sends a ping message to keep the connection alive.
      */
     private ping = async () => {
-        if (this.ws.readyState !== WebSocket.OPEN) {
-            return console.warn("Socket not open. Ready state is:", this.ws.readyState);
-        }
-
-        this.ws.send("ping", (err: Error | undefined) => {
-            if (err) {
-                console.error("ping error", err);
+        if(this.ws) {
+            if (this.ws.readyState !== WebSocket.OPEN) {
+                return console.warn("Socket not open. Ready state is:", this.ws.readyState);
             }
-        });
+    
+            this.ws.send("ping", (err: Error | undefined) => {
+                if (err) {
+                    console.error("ping error", err);
+                }
+            });
+        }
     };
 
     /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -120,9 +120,9 @@ export class RealTimeDataClient {
      * Handles WebSocket errors. Logs the error and attempts reconnection if `autoReconnect` is enabled.
      * @param err Error object describing the issue.
      */
-    private onError = async (err: ErrorEvent) => {        
-        this.notifyStatusChange(ConnectionStatus.DISCONNECTED);
+    private onError = async (err: ErrorEvent) => {   
         console.error("error", err);
+        this.notifyStatusChange(ConnectionStatus.DISCONNECTED);
         if (this.ws) {
             this.ws.removeAllListeners();
             this.ws.terminate();
@@ -140,12 +140,12 @@ export class RealTimeDataClient {
      */
     private onClose = async (message: CloseEvent) => {
         console.error("disconnected", "code", message.code, "reason", message.reason);
+        this.notifyStatusChange(ConnectionStatus.DISCONNECTED);
         if (this.ws) {
             this.ws.removeAllListeners();
             this.ws.terminate();
             this.ws = null;
         }
-        this.notifyStatusChange(ConnectionStatus.DISCONNECTED);
         if (this.autoReconnect) {
             this.connect();
         }


### PR DESCRIPTION
Heap out of memory error happened, because WebSocket instance was not terminated when establishing new one, leading to massive spike in memory on network errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core connection lifecycle and reconnect behavior; incorrect cleanup could drop subscriptions or cause double-reconnect edge cases, but the fix is narrowly scoped to teardown and guards.
> 
> **Overview**
> Fixes heap out-of-memory when network failures trigger repeated reconnects by **fully tearing down** the previous WebSocket before opening a new one.
> 
> On **error** and **close**, the client now removes listeners, calls `terminate()`, and sets `this.ws` to `null` before `autoReconnect` runs `connect()` again. **Error** handling also emits `DISCONNECTED` via `notifyStatusChange`. **Ping/pong**, **disconnect**, **subscribe**, and **unsubscribe** guard against a missing socket so stale timers or API calls cannot touch a dead instance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31809487db60dcab08b5efc566fa3317bbdf10a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->