### PR TITLE
fix: use ?? for autoReconnect default and add onClose/onError callbacks (closes #43)

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -144,7 +144,11 @@ export class RealTimeDataClient {
     private onError = async (err: ErrorEvent) => {
         console.error("error", err);
         if (this.onErrorCallback) {
-            this.onErrorCallback(err);
+            try {
+                this.onErrorCallback(err);
+            } catch (e) {
+                console.error('Error in onErrorCallback:', e);
+            }
         }
         if (this.autoReconnect) {
             this.connect();

--- a/src/client.ts
+++ b/src/client.ts
@@ -38,6 +38,19 @@ export interface RealTimeDataClientArgs {
     pingInterval?: number;
 
     /**
+     * Optional callback function that is called when the connection is closed.
+     * @param code - The close code.
+     * @param reason - The reason for closure.
+     */
+    onClose?: (code: number, reason: string) => void;
+
+    /**
+     * Optional callback function that is called when a connection error occurs.
+     * @param error - The error event.
+     */
+    onError?: (error: ErrorEvent) => void;
+
+    /**
      * Optional flag to enable or disable automatic reconnection when the connection is lost.
      */
     autoReconnect?: boolean;
@@ -66,6 +79,12 @@ export class RealTimeDataClient {
     /** Callback function executed on a connection status update */
     private readonly onStatusChange?: (status: ConnectionStatus) => void;
 
+    /** Callback function executed when the connection is closed */
+    private readonly onCloseCallback?: (code: number, reason: string) => void;
+
+    /** Callback function executed when a connection error occurs */
+    private readonly onErrorCallback?: (error: ErrorEvent) => void;
+
     /** WebSocket instance */
     private ws!: WebSocket;
 
@@ -76,10 +95,12 @@ export class RealTimeDataClient {
     constructor(args?: RealTimeDataClientArgs) {
         this.host = args!.host || DEFAULT_HOST;
         this.pingInterval = args!.pingInterval || DEFAULT_PING_INTERVAL;
-        this.autoReconnect = args!.autoReconnect || true;
+        this.autoReconnect = args!.autoReconnect ?? true;
         this.onCustomMessage = args!.onMessage;
         this.onConnect = args!.onConnect;
         this.onStatusChange = args!.onStatusChange;
+        this.onCloseCallback = args!.onClose;
+        this.onErrorCallback = args!.onError;
     }
 
     /**
@@ -122,6 +143,9 @@ export class RealTimeDataClient {
      */
     private onError = async (err: ErrorEvent) => {
         console.error("error", err);
+        if (this.onErrorCallback) {
+            this.onErrorCallback(err);
+        }
         if (this.autoReconnect) {
             this.connect();
         }
@@ -135,6 +159,9 @@ export class RealTimeDataClient {
     private onClose = async (message: CloseEvent) => {
         console.error("disconnected", "code", message.code, "reason", message.reason);
         this.notifyStatusChange(ConnectionStatus.DISCONNECTED);
+        if (this.onCloseCallback) {
+            this.onCloseCallback(message.code, String(message.reason));
+        }
         if (this.autoReconnect) {
             this.connect();
         }

--- a/src/client.ts
+++ b/src/client.ts
@@ -164,7 +164,11 @@ export class RealTimeDataClient {
         console.error("disconnected", "code", message.code, "reason", message.reason);
         this.notifyStatusChange(ConnectionStatus.DISCONNECTED);
         if (this.onCloseCallback) {
-            this.onCloseCallback(message.code, String(message.reason));
+            try {
+                this.onCloseCallback(message.code, String(message.reason));
+            } catch (e) {
+                console.error('Error in onCloseCallback:', e);
+            }
         }
         if (this.autoReconnect) {
             this.connect();


### PR DESCRIPTION
## Problem
Two bugs in `RealTimeDataClientArgs` initialization:

**1. `autoReconnect: false` silently ignored**
`args!.autoReconnect || true` treats `false` as falsy, so the client
always reconnects regardless of the user's intent.

**2. No `onClose` / `onError` callbacks**
Callers have no way to react to connection drops or errors from
application code. This is the root cause of #26 where streams silently
die after ~20 minutes.

## Fix
- Replace `||` with `??` for `autoReconnect` default assignment
- Add `onClose?: (code: number, reason: string) => void` to interface
- Add `onError?: (error: ErrorEvent) => void` to interface
- Wire both callbacks into the existing `onClose` and `onError` handlers

## Usage after fix
```ts
new RealTimeDataClient({
  autoReconnect: false, // now actually respected
  onClose: (code, reason) => console.log('closed', code, reason),
  onError: (err) => console.error('error', err),
}).connect();
```

Closes #43
Relates to #26

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized changes to WebSocket lifecycle handling; main impact is altering reconnection behavior when users explicitly set `autoReconnect: false`.
> 
> **Overview**
> Fixes `RealTimeDataClient` initialization so `autoReconnect: false` is respected by switching the defaulting logic to `??`.
> 
> Extends `RealTimeDataClientArgs` with `onClose` and `onError` callbacks and wires them into the existing WebSocket handlers (with try/catch) so callers can react to disconnects and errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 778a5c4c39da69a8d5a9936663b6899c0897649a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->