### PR TITLE
fix: use ?? for autoReconnect default; add onClose and onError callbacks

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -91,10 +91,13 @@ export class RealTimeDataClient {
     /** WebSocket instance */
     private ws!: WebSocket;
 
-    /** Guard flag: true while a reconnect is already in flight, preventing
-     *  a second connect() call when both onError and the subsequent onClose
-     *  fire in quick succession on the same error-driven disconnect. */
-    private isReconnecting = false;
+    /** Monotonically-increasing counter stamped onto each socket at connect()
+     *  time. close/error handlers compare their captured id against this value
+     *  to decide whether they belong to the current socket or a stale dying one.
+     *  This is the only reliable way to prevent double-reconnect from onError+onClose
+     *  firing on the same socket while also allowing retry when a reconnect attempt
+     *  itself fails before onOpen. (Cursor Bugbot review) */
+    private connectionId = 0;
 
     /**
      * Constructs a new RealTimeDataClient instance.
@@ -120,13 +123,17 @@ export class RealTimeDataClient {
      * Establishes a WebSocket connection to the server.
      */
     public connect() {
+        // Stamp this socket with a unique id. Handlers that capture this id
+        // can detect whether they belong to the current socket or a stale one.
+        const id = ++this.connectionId;
         this.notifyStatusChange(ConnectionStatus.CONNECTING);
         this.ws = new WebSocket(this.host);
         if (this.ws) {
             this.ws.onopen = this.onOpen;
             this.ws.onmessage = this.onMessage;
-            this.ws.onclose = this.onClose;
-            this.ws.onerror = this.onError;
+            // Lambdas (not direct assignment) so we can pass the id through.
+            this.ws.onclose = (event: CloseEvent) => this.onClose(event, id);
+            this.ws.onerror = (err: ErrorEvent) => this.onError(err, id);
             this.ws.pong = this.onPong;
         }
         return this;
@@ -136,11 +143,6 @@ export class RealTimeDataClient {
      * Handles WebSocket 'open' event. Executes the `onConnect` callback and starts pinging.
      */
     private onOpen = async () => {
-        // The new socket is established: clear the guard so future disconnects
-        // on this socket can trigger a fresh reconnect. (Cursor Bugbot review:
-        // clearing it in connect() reset the flag before the dying socket's
-        // onClose fired, allowing a duplicate reconnect.)
-        this.isReconnecting = false;
         this.ping();
         this.notifyStatusChange(ConnectionStatus.CONNECTED);
         if (this.onConnect) {
@@ -160,7 +162,12 @@ export class RealTimeDataClient {
      * then attempts reconnection if `autoReconnect` is enabled.
      * @param err Error object describing the issue.
      */
-    private onError = async (err: ErrorEvent) => {
+    private onError = async (err: ErrorEvent, id: number) => {
+        // Stale socket: a newer connection is already in flight.
+        // onError on the dying old socket after we already called connect() — ignore.
+        if (id !== this.connectionId) {
+            return;
+        }
         console.error("error", err);
         // Guard: wrap callback so a throwing onError handler does not abort
         // the autoReconnect logic below. (Graphite review)
@@ -171,13 +178,9 @@ export class RealTimeDataClient {
         } catch (callbackError) {
             console.error("Error in onError callback:", callbackError);
         }
-        if (this.autoReconnect && !this.isReconnecting) {
-            // Set the guard before connect() so that the dying socket's natural
-            // close event (which fires shortly after the error) finds the flag
-            // already set and skips the second connect() call — while still
-            // delivering the DISCONNECTED status and onClose callback normally.
-            // (Cursor Bugbot review: ws.onclose=null suppressed those notifications)
-            this.isReconnecting = true;
+        // connect() increments connectionId, so the dying socket's onClose
+        // (which fires next) will see id !== connectionId and return early.
+        if (this.autoReconnect) {
             this.connect();
         }
     };
@@ -187,7 +190,13 @@ export class RealTimeDataClient {
      * logs the disconnect reason, and attempts reconnection if `autoReconnect` is enabled.
      * @param message Close event containing code and reason.
      */
-    private onClose = async (message: CloseEvent) => {
+    private onClose = async (message: CloseEvent, id: number) => {
+        // Stale socket: onError already triggered connect() for this socket,
+        // incrementing connectionId. Suppress all notifications to prevent a
+        // spurious DISCONNECTED status after the new connection is in flight.
+        if (id !== this.connectionId) {
+            return;
+        }
         console.error("disconnected", "code", message.code, "reason", message.reason);
         this.notifyStatusChange(ConnectionStatus.DISCONNECTED);
         // Guard: wrap callback so a throwing onClose handler does not abort
@@ -199,8 +208,11 @@ export class RealTimeDataClient {
         } catch (callbackError) {
             console.error("Error in onClose callback:", callbackError);
         }
-        if (this.autoReconnect && !this.isReconnecting) {
-            this.isReconnecting = true;
+        // id === connectionId here, so this is the current socket closing.
+        // connect() will increment connectionId; if onError already fired and
+        // called connect(), this onClose will have id !== connectionId (caught
+        // by the early return above). Safe to reconnect unconditionally here.
+        if (this.autoReconnect) {
             this.connect();
         }
     };

--- a/src/client.ts
+++ b/src/client.ts
@@ -149,10 +149,21 @@ export class RealTimeDataClient {
      */
     private onError = async (err: ErrorEvent) => {
         console.error("error", err);
-        if (this.onUserError) {
-            this.onUserError(this, err);
+        // Guard: wrap callback so a throwing onError handler does not abort
+        // the autoReconnect logic below. (Graphite review)
+        try {
+            if (this.onUserError) {
+                this.onUserError(this, err);
+            }
+        } catch (callbackError) {
+            console.error("Error in onError callback:", callbackError);
         }
         if (this.autoReconnect) {
+            // Detach the close handler from the dying socket before connect()
+            // replaces this.ws. Without this, the old socket fires its natural
+            // close event after the error, causing a spurious onUserClose call
+            // and a second connect() loop. (Cursor Bugbot review)
+            this.ws.onclose = null;
             this.connect();
         }
     };
@@ -165,8 +176,14 @@ export class RealTimeDataClient {
     private onClose = async (message: CloseEvent) => {
         console.error("disconnected", "code", message.code, "reason", message.reason);
         this.notifyStatusChange(ConnectionStatus.DISCONNECTED);
-        if (this.onUserClose) {
-            this.onUserClose(this, message);
+        // Guard: wrap callback so a throwing onClose handler does not abort
+        // the autoReconnect logic below. (Symmetric with onError fix)
+        try {
+            if (this.onUserClose) {
+                this.onUserClose(this, message);
+            }
+        } catch (callbackError) {
+            console.error("Error in onClose callback:", callbackError);
         }
         if (this.autoReconnect) {
             this.connect();

--- a/src/client.ts
+++ b/src/client.ts
@@ -101,16 +101,19 @@ export class RealTimeDataClient {
      * @param args Configuration options for the client.
      */
     constructor(args?: RealTimeDataClientArgs) {
-        this.host = args!.host || DEFAULT_HOST;
-        this.pingInterval = args!.pingInterval || DEFAULT_PING_INTERVAL;
+        // Use optional chaining (args?.) throughout so that calling
+        // new RealTimeDataClient() with no arguments does not throw
+        // "Cannot read properties of undefined". (Graphite review)
+        this.host = args?.host || DEFAULT_HOST;
+        this.pingInterval = args?.pingInterval || DEFAULT_PING_INTERVAL;
         // Fix: use ?? instead of || so that explicitly passing `false` is respected.
         // Using `|| true` treated false as falsy and always enabled autoReconnect.
-        this.autoReconnect = args!.autoReconnect ?? true;
-        this.onCustomMessage = args!.onMessage;
-        this.onConnect = args!.onConnect;
-        this.onStatusChange = args!.onStatusChange;
-        this.onUserClose = args!.onClose;
-        this.onUserError = args!.onError;
+        this.autoReconnect = args?.autoReconnect ?? true;
+        this.onCustomMessage = args?.onMessage;
+        this.onConnect = args?.onConnect;
+        this.onStatusChange = args?.onStatusChange;
+        this.onUserClose = args?.onClose;
+        this.onUserError = args?.onError;
     }
 
     /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -283,7 +283,12 @@ export class RealTimeDataClient {
      */
     public disconnect() {
         this.autoReconnect = false;
-        this.ws.close();
+        // Guard against calling close() before connect() has been called
+        // (this.ws is uninitialized — declared with ! assertion) and against
+        // closing a socket that is already CLOSING or CLOSED. (Graphite review)
+        if (this.ws && this.ws.readyState !== WebSocket.CLOSED && this.ws.readyState !== WebSocket.CLOSING) {
+            this.ws.close();
+        }
     }
 
     /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -28,6 +28,21 @@ export interface RealTimeDataClientArgs {
     onStatusChange?: (status: ConnectionStatus) => void;
 
     /**
+     * Optional callback function that is called when the connection is closed.
+     * Receives the close event so callers can inspect the code and reason.
+     * @param client - The instance of the RealTimeDataClient that disconnected.
+     * @param event - The WebSocket CloseEvent containing code and reason.
+     */
+    onClose?: (client: RealTimeDataClient, event: CloseEvent) => void;
+
+    /**
+     * Optional callback function that is called when a WebSocket error occurs.
+     * @param client - The instance of the RealTimeDataClient that errored.
+     * @param error - The ErrorEvent describing the error.
+     */
+    onError?: (client: RealTimeDataClient, error: ErrorEvent) => void;
+
+    /**
      * Optional host address to connect to.
      */
     host?: string;
@@ -39,6 +54,7 @@ export interface RealTimeDataClientArgs {
 
     /**
      * Optional flag to enable or disable automatic reconnection when the connection is lost.
+     * Defaults to true.
      */
     autoReconnect?: boolean;
 }
@@ -66,6 +82,12 @@ export class RealTimeDataClient {
     /** Callback function executed on a connection status update */
     private readonly onStatusChange?: (status: ConnectionStatus) => void;
 
+    /** User-provided callback executed when the connection closes */
+    private readonly onUserClose?: (client: RealTimeDataClient, event: CloseEvent) => void;
+
+    /** User-provided callback executed when a WebSocket error occurs */
+    private readonly onUserError?: (client: RealTimeDataClient, error: ErrorEvent) => void;
+
     /** WebSocket instance */
     private ws!: WebSocket;
 
@@ -76,10 +98,14 @@ export class RealTimeDataClient {
     constructor(args?: RealTimeDataClientArgs) {
         this.host = args!.host || DEFAULT_HOST;
         this.pingInterval = args!.pingInterval || DEFAULT_PING_INTERVAL;
-        this.autoReconnect = args!.autoReconnect || true;
+        // Fix: use ?? instead of || so that explicitly passing `false` is respected.
+        // Using `|| true` treated false as falsy and always enabled autoReconnect.
+        this.autoReconnect = args!.autoReconnect ?? true;
         this.onCustomMessage = args!.onMessage;
         this.onConnect = args!.onConnect;
         this.onStatusChange = args!.onStatusChange;
+        this.onUserClose = args!.onClose;
+        this.onUserError = args!.onError;
     }
 
     /**
@@ -117,24 +143,31 @@ export class RealTimeDataClient {
     };
 
     /**
-     * Handles WebSocket errors. Logs the error and attempts reconnection if `autoReconnect` is enabled.
+     * Handles WebSocket errors. Invokes the user-provided onError callback (if any),
+     * then attempts reconnection if `autoReconnect` is enabled.
      * @param err Error object describing the issue.
      */
     private onError = async (err: ErrorEvent) => {
         console.error("error", err);
+        if (this.onUserError) {
+            this.onUserError(this, err);
+        }
         if (this.autoReconnect) {
             this.connect();
         }
     };
 
     /**
-     * Handles WebSocket 'close' event. Logs the disconnect reason and attempts reconnection if `autoReconnect` is enabled.
-     * @param code Close event code.
-     * @param reason Buffer containing the reason for closure.
+     * Handles WebSocket 'close' event. Invokes the user-provided onClose callback (if any),
+     * logs the disconnect reason, and attempts reconnection if `autoReconnect` is enabled.
+     * @param message Close event containing code and reason.
      */
     private onClose = async (message: CloseEvent) => {
         console.error("disconnected", "code", message.code, "reason", message.reason);
         this.notifyStatusChange(ConnectionStatus.DISCONNECTED);
+        if (this.onUserClose) {
+            this.onUserClose(this, message);
+        }
         if (this.autoReconnect) {
             this.connect();
         }
@@ -171,14 +204,6 @@ export class RealTimeDataClient {
     };
 
     /**
-     * Closes the WebSocket connection.
-     */
-    public disconnect() {
-        this.autoReconnect = false;
-        this.ws.close();
-    }
-
-    /**
      * Subscribes to a data stream by sending a subscription message.
      * @param msg Subscription request message.
      */
@@ -209,6 +234,14 @@ export class RealTimeDataClient {
                 this.ws.close();
             }
         });
+    }
+
+    /**
+     * Closes the WebSocket connection.
+     */
+    public disconnect() {
+        this.autoReconnect = false;
+        this.ws.close();
     }
 
     /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -91,6 +91,11 @@ export class RealTimeDataClient {
     /** WebSocket instance */
     private ws!: WebSocket;
 
+    /** Guard flag: true while a reconnect is already in flight, preventing
+     *  a second connect() call when both onError and the subsequent onClose
+     *  fire in quick succession on the same error-driven disconnect. */
+    private isReconnecting = false;
+
     /**
      * Constructs a new RealTimeDataClient instance.
      * @param args Configuration options for the client.
@@ -112,6 +117,7 @@ export class RealTimeDataClient {
      * Establishes a WebSocket connection to the server.
      */
     public connect() {
+        this.isReconnecting = false;
         this.notifyStatusChange(ConnectionStatus.CONNECTING);
         this.ws = new WebSocket(this.host);
         if (this.ws) {
@@ -158,12 +164,13 @@ export class RealTimeDataClient {
         } catch (callbackError) {
             console.error("Error in onError callback:", callbackError);
         }
-        if (this.autoReconnect) {
-            // Detach the close handler from the dying socket before connect()
-            // replaces this.ws. Without this, the old socket fires its natural
-            // close event after the error, causing a spurious onUserClose call
-            // and a second connect() loop. (Cursor Bugbot review)
-            this.ws.onclose = null;
+        if (this.autoReconnect && !this.isReconnecting) {
+            // Set the guard before connect() so that the dying socket's natural
+            // close event (which fires shortly after the error) finds the flag
+            // already set and skips the second connect() call — while still
+            // delivering the DISCONNECTED status and onClose callback normally.
+            // (Cursor Bugbot review: ws.onclose=null suppressed those notifications)
+            this.isReconnecting = true;
             this.connect();
         }
     };
@@ -185,7 +192,8 @@ export class RealTimeDataClient {
         } catch (callbackError) {
             console.error("Error in onClose callback:", callbackError);
         }
-        if (this.autoReconnect) {
+        if (this.autoReconnect && !this.isReconnecting) {
+            this.isReconnecting = true;
             this.connect();
         }
     };

--- a/src/client.ts
+++ b/src/client.ts
@@ -191,12 +191,11 @@ export class RealTimeDataClient {
      * @param message Close event containing code and reason.
      */
     private onClose = async (message: CloseEvent, id: number) => {
-        // Stale socket: onError already triggered connect() for this socket,
-        // incrementing connectionId. Suppress all notifications to prevent a
-        // spurious DISCONNECTED status after the new connection is in flight.
-        if (id !== this.connectionId) {
-            return;
-        }
+        // Always deliver DISCONNECTED and the onUserClose callback regardless
+        // of whether this is a stale socket. The CloseEvent carries close-code
+        // and reason details that are only available here (not in onError), so
+        // callers need them even when onError already ran and a reconnect is
+        // already in flight. (Cursor Bugbot: "Stale close skips callbacks")
         console.error("disconnected", "code", message.code, "reason", message.reason);
         this.notifyStatusChange(ConnectionStatus.DISCONNECTED);
         // Guard: wrap callback so a throwing onClose handler does not abort
@@ -208,11 +207,10 @@ export class RealTimeDataClient {
         } catch (callbackError) {
             console.error("Error in onClose callback:", callbackError);
         }
-        // id === connectionId here, so this is the current socket closing.
-        // connect() will increment connectionId; if onError already fired and
-        // called connect(), this onClose will have id !== connectionId (caught
-        // by the early return above). Safe to reconnect unconditionally here.
-        if (this.autoReconnect) {
+        // Only trigger a reconnect from the current socket. If onError already
+        // called connect() for this socket, connectionId was incremented and id
+        // is now stale — skip to avoid opening a duplicate connection.
+        if (this.autoReconnect && id === this.connectionId) {
             this.connect();
         }
     };

--- a/src/client.ts
+++ b/src/client.ts
@@ -120,7 +120,6 @@ export class RealTimeDataClient {
      * Establishes a WebSocket connection to the server.
      */
     public connect() {
-        this.isReconnecting = false;
         this.notifyStatusChange(ConnectionStatus.CONNECTING);
         this.ws = new WebSocket(this.host);
         if (this.ws) {
@@ -137,6 +136,11 @@ export class RealTimeDataClient {
      * Handles WebSocket 'open' event. Executes the `onConnect` callback and starts pinging.
      */
     private onOpen = async () => {
+        // The new socket is established: clear the guard so future disconnects
+        // on this socket can trigger a fresh reconnect. (Cursor Bugbot review:
+        // clearing it in connect() reset the flag before the dying socket's
+        // onClose fired, allowing a duplicate reconnect.)
+        this.isReconnecting = false;
         this.ping();
         this.notifyStatusChange(ConnectionStatus.CONNECTED);
         if (this.onConnect) {


### PR DESCRIPTION
## Summary

Fixes two bugs in `src/client.ts` reported in #43.

---

### Bug 1: `autoReconnect: false` is silently ignored

**Root cause:** The constructor used `||` (logical OR), which treats `false` as falsy and always falls back to `true`:

```typescript
// Before — always evaluates to true, even when caller passes false
this.autoReconnect = args!.autoReconnect || true;
```

**Fix:** Replace with `??` (nullish coalescing), which only falls back on `null` or `undefined`:

```typescript
// After — respects explicit false
this.autoReconnect = args!.autoReconnect ?? true;
```

---

### Bug 2: No `onClose` or `onError` callbacks exposed to callers

`RealTimeDataClientArgs` only offered `onConnect`, `onMessage`, and `onStatusChange`. Users had no way to react to disconnect events or errors — they could not implement application-level watchdogs, structured logging, or custom back-off strategies.

**Fix:** Added two new optional callbacks to both the interface and the class:

```typescript
// New interface additions
onClose?: (client: RealTimeDataClient, event: CloseEvent) => void;
onError?: (client: RealTimeDataClient, error: ErrorEvent) => void;
```

Both callbacks fire **before** the existing reconnect logic, so callers can:
- Log the disconnect reason and error code
- Update external state / UI
- Implement custom exponential back-off (by setting `autoReconnect: false` and calling `connect()` themselves on a timer)

---

### Example usage after this fix

```typescript
const client = new RealTimeDataClient({
  autoReconnect: false, // now actually respected
  onClose: (c, event) => {
    console.warn(`Disconnected (code ${event.code}): ${event.reason}`);
    // custom back-off
    setTimeout(() => c.connect(), 5_000);
  },
  onError: (c, err) => {
    console.error("WS error:", err);
    metrics.increment("ws.error");
  },
});
```

---

### Testing

- Verified that passing `autoReconnect: false` now prevents automatic reconnection on close/error
- Verified `onClose` fires with the correct `CloseEvent` (code + reason) before the reconnect gate
- Verified `onError` fires with the `ErrorEvent` before the reconnect gate
- No existing behaviour changed when `autoReconnect` is omitted (defaults to `true`) or when `onClose`/`onError` are not provided

Fixes #43

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core connection teardown and auto-reconnect behavior; fixes are targeted but affect all consumers relying on reconnect semantics.
> 
> **Overview**
> Fixes **`autoReconnect: false`** being ignored by defaulting with **`??`** instead of **`||`**, and exposes optional **`onClose`** / **`onError`** hooks so apps can log disconnects and implement custom backoff.
> 
> **Reconnect lifecycle** is tightened: each `connect()` stamps a **`connectionId`** so stale sockets don’t trigger a second reconnect when both error and close fire; user callbacks are wrapped in **try/catch** so thrown handlers don’t block auto-reconnect. **`onClose`** still runs (and status goes **DISCONNECTED**) even when the socket is stale, so close code/reason aren’t dropped.
> 
> **Constructor** uses optional **`args?.`** so `new RealTimeDataClient()` is safe. **`disconnect()`** only closes when the socket exists and isn’t already closing/closed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ae00c6c34df4e783459e71557602d95ecd4fbc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->