### PR TITLE
fix: exponential back-off reconnect + onClose/onError callbacks + autoReconnect ?? fix

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -133,15 +133,21 @@ import WebSocket, { MessageEvent, CloseEvent, ErrorEvent } from "isomorphic-ws";
 
       /**
        * The id of the most recent socket that successfully reached the OPEN state.
-       * Set to the socket's id inside onOpen.
+       * Set to the socket's id inside onOpen alongside the CONNECTED status emission.
        *
-       * Used by onClose to decide whether to emit DISCONNECTED and invoke onUserClose
-       * even when connectionId has already advanced (e.g. because onUserError or a
-       * manual caller invoked connect() before the close event fired). A socket that
-       * genuinely connected deserves a DISCONNECTED notification regardless of whether
-       * a replacement socket is already opening. A socket that was replaced before it
-       * ever opened does not — it never published a CONNECTED status so there is no
-       * paired DISCONNECTED to emit.
+       * Used by onClose to make two independent decisions:
+       *
+       * 1. Notify? — only if wasConnected (id === lastConnectedId).
+       *    A socket that reached CONNECTED published a status event; its close must
+       *    publish the paired DISCONNECTED. A socket that never opened (failed
+       *    handshake, or replaced before connecting) must NOT emit DISCONNECTED —
+       *    doing so violates the state machine by producing CONNECTING → DISCONNECTED
+       *    without CONNECTED in between.
+       *
+       * 2. Reconnect? — only if isCurrent (id === connectionId).
+       *    Retry the connection regardless of whether the socket ever connected;
+       *    a failed handshake is just as much a reason to back-off and retry as a
+       *    mid-session drop. Skip if a replacement socket is already opening.
        */
       private lastConnectedId = -1;
 
@@ -174,9 +180,10 @@ import WebSocket, { MessageEvent, CloseEvent, ErrorEvent } from "isomorphic-ws";
        *   and connection-limit leaks when connect() is called while a socket is live.
        *
        * Ordering is critical: connectionId is incremented BEFORE the old socket is
-       * closed. This ensures the old socket's onClose/onError handlers see a stale id
-       * and apply the correct notification logic (emit DISCONNECTED if the socket was
-       * ever connected, skip reconnect since a replacement is already starting).
+       * closed. This ensures the old socket's onClose handler sees a stale id and
+       * applies the correct notification logic — emit DISCONNECTED only if it was
+       * ever connected (lastConnectedId), skip reconnect since a replacement is
+       * already starting.
        *
        * Also resets reconnectAttempt when it cancels a pending timer, so a manual
        * reconnect always starts the back-off sequence from the initial delay.
@@ -190,14 +197,13 @@ import WebSocket, { MessageEvent, CloseEvent, ErrorEvent } from "isomorphic-ws";
               this.reconnectAttempt = 0;
           }
 
-          // Increment connectionId FIRST. Old socket handlers capture the previous id
-          // and will use it to decide whether to emit notifications (based on
-          // lastConnectedId) vs. whether to schedule a reconnect (based on connectionId).
+          // Increment connectionId FIRST so that when we close the old socket below,
+          // its onClose fires with a stale id and follows the correct notification
+          // path (emit DISCONNECTED only if it was previously connected).
           const id = ++this.connectionId;
 
-          // Close the previous socket if it is still open. Without this, each call to
-          // connect() while a socket is live abandons the old socket on the network,
-          // leaking file descriptors and browser/server connection slots.
+          // Close the previous socket if still open to prevent resource leaks.
+          // Handlers are already stale (id check) so this close is silent.
           if (this.ws && this.ws.readyState !== WebSocket.CLOSED && this.ws.readyState !== WebSocket.CLOSING) {
               this.ws.close();
           }
@@ -215,19 +221,19 @@ import WebSocket, { MessageEvent, CloseEvent, ErrorEvent } from "isomorphic-ws";
       }
 
       /**
-       * Handles WebSocket open event. Resets back-off, records lastConnectedId,
-       * starts pinging, and fires onConnect.
+       * Handles WebSocket open event. Records lastConnectedId, resets back-off,
+       * starts pinging, emits CONNECTED, and fires onConnect.
        *
-       * Recording lastConnectedId here is the key: it marks this socket as having
-       * genuinely reached CONNECTED state, so that onClose can emit a paired
-       * DISCONNECTED notification even if connectionId has advanced by then.
+       * Setting lastConnectedId here is the authoritative record that this socket
+       * reached CONNECTED state. onClose uses it to decide whether to emit the
+       * paired DISCONNECTED notification.
        *
        * Guards against stale open events from superseded sockets.
        */
       private onOpen = (id: number) => {
           if (id !== this.connectionId) return;
-          this.reconnectAttempt = 0;
           this.lastConnectedId = id;
+          this.reconnectAttempt = 0;
           this.ping();
           this.notifyStatusChange(ConnectionStatus.CONNECTED);
           if (this.onConnect) {
@@ -236,12 +242,9 @@ import WebSocket, { MessageEvent, CloseEvent, ErrorEvent } from "isomorphic-ws";
       };
 
       /**
-       * Handles WebSocket pong event. Schedules the next ping after the configured interval.
-       *
-       * Captures connectionId at the moment the pong arrives and re-checks it when the
-       * delay resolves. If connect() has superseded the socket in the meantime, the stale
-       * pong chain's deferred ping() call is suppressed — preventing duplicate keepalive
-       * traffic on the new connection from an old, dead ping/pong loop.
+       * Handles WebSocket pong event. Schedules the next ping after the configured
+       * interval, tied to the connection id so a stale pong chain from a superseded
+       * socket cannot duplicate keepalive traffic on the current connection.
        */
       private onPong = (id: number) => {
           delay(this.pingInterval).then(() => {
@@ -254,16 +257,12 @@ import WebSocket, { MessageEvent, CloseEvent, ErrorEvent } from "isomorphic-ws";
       /**
        * Handles WebSocket errors. Notifies the user onError callback.
        *
-       * Does NOT emit notifyStatusChange(DISCONNECTED) here — onClose always fires
-       * after onError in the WebSocket lifecycle, so DISCONNECTED is emitted exactly
-       * once from onClose. Emitting it here too would cause onStatusChange to fire
-       * twice for a single connection drop.
+       * Does NOT emit DISCONNECTED — onClose always fires after onError in the
+       * WebSocket lifecycle and is the single place that decides whether to emit
+       * DISCONNECTED (only when the socket previously reached CONNECTED state).
        *
-       * Does NOT call scheduleReconnect() here for the same reason: onClose will
-       * handle reconnection once, preventing a double-reconnect.
-       *
-       * Guards with id === connectionId so that a stale error from a previous socket
-       * does not invoke the user's onError callback while the current socket is healthy.
+       * Does NOT schedule a reconnect — onClose handles that too, preventing a
+       * double-reconnect from both handlers firing on the same socket.
        */
       private onError = (id: number, err: ErrorEvent) => {
           if (id !== this.connectionId) return;
@@ -274,42 +273,51 @@ import WebSocket, { MessageEvent, CloseEvent, ErrorEvent } from "isomorphic-ws";
       };
 
       /**
-       * Handles WebSocket close event. Emits DISCONNECTED status, fires onClose callback,
-       * and schedules a reconnect with exponential back-off when appropriate.
+       * Handles WebSocket close event.
        *
-       * Two independent questions are answered with two independent checks:
+       * Three independent concerns are separated using two flags:
+       *   wasConnected = id === lastConnectedId  (socket reached OPEN state)
+       *   isCurrent    = id === connectionId     (no replacement socket started yet)
        *
-       * 1. Should we notify? (emit DISCONNECTED + invoke onUserClose)
-       *    Yes if this socket previously emitted CONNECTED (id === lastConnectedId).
-       *    This covers the case where connect() or disconnect() was called before the
-       *    close event fired — the socket genuinely was active and its close is
-       *    observable. A socket replaced before it ever opened is silently dropped
-       *    because no CONNECTED was ever published for it, so there is no paired
-       *    DISCONNECTED to emit.
+       * 1. DROP SILENTLY — if !wasConnected && !isCurrent
+       *    The socket never connected AND has already been superseded. Nothing was
+       *    ever published for it so there is nothing to unpublish.
        *
-       * 2. Should we reconnect? (scheduleReconnect)
-       *    Only if no replacement socket has been started yet (id === connectionId)
-       *    AND autoReconnect is enabled AND the user's onClose callback did not
-       *    itself call connect() (second connectionId re-check after the callback).
+       * 2. NOTIFY (DISCONNECTED + onUserClose) — only if wasConnected
+       *    A socket that reached CONNECTED published that status; its close must
+       *    emit the paired DISCONNECTED regardless of whether connectionId has
+       *    since advanced. A socket that closed before onOpen fired (failed
+       *    handshake, immediate network error) must NOT emit DISCONNECTED — that
+       *    would produce CONNECTING → DISCONNECTED without CONNECTED in between,
+       *    violating the state machine.
+       *
+       * 3. RECONNECT (scheduleReconnect) — only if isCurrent
+       *    Retry whenever the current socket closes, whether or not it ever
+       *    connected — a failed handshake is just as valid a reason to back-off
+       *    and retry as a mid-session drop. Skip if a replacement is already open.
+       *    Re-check connectionId after the user callback in case it called connect().
        */
       private onClose = (id: number, message: CloseEvent) => {
           const wasConnected = id === this.lastConnectedId;
           const isCurrent    = id === this.connectionId;
 
-          // Drop silently if this socket never reached CONNECTED and has already been
-          // superseded — nothing was published for it so there is nothing to unpublish.
           if (!wasConnected && !isCurrent) return;
 
           console.error("disconnected", "code", message.code, "reason", message.reason);
-          this.notifyStatusChange(ConnectionStatus.DISCONNECTED);
 
-          if (this.onUserClose) {
-              try { this.onUserClose(this, message); } catch (e) { console.error("onClose callback threw:", e); }
+          // Emit DISCONNECTED and invoke onUserClose only when the socket previously
+          // reached CONNECTED state. A failed-handshake close must not emit DISCONNECTED
+          // (no CONNECTED was published so there is no paired status to unpublish).
+          if (wasConnected) {
+              this.notifyStatusChange(ConnectionStatus.DISCONNECTED);
+              if (this.onUserClose) {
+                  try { this.onUserClose(this, message); } catch (e) { console.error("onClose callback threw:", e); }
+              }
           }
 
-          // Re-check connectionId after the user callback: the callback may have called
-          // connect(), which increments connectionId. If it did, a socket is already
-          // opening and we must not also schedule a reconnect on top of it.
+          // Reconnect if this is still the active connection and autoReconnect is on.
+          // Re-check connectionId after the user callback: if onUserClose called connect(),
+          // connectionId has advanced and we must not open a second socket on top.
           if (this.autoReconnect && isCurrent && id === this.connectionId) {
               this.scheduleReconnect();
           }
@@ -320,15 +328,9 @@ import WebSocket, { MessageEvent, CloseEvent, ErrorEvent } from "isomorphic-ws";
        *
        *   delay = min(reconnectDelay x 2^attempt, maxReconnectDelay) + rand(0..1000) ms
        *
-       * Back-off prevents thundering herd on server restarts and stops the heap-memory
-       * growth observed when a persistent network error (e.g. close code 1006) causes
-       * connect() to be called in a tight loop, accumulating WebSocket objects faster
-       * than the garbage collector can free them (see issue #38).
-       *
-       * The timer callback re-checks autoReconnect before calling connect(). This closes
-       * a race window where disconnect() is called after the timer has already fired and
-       * its callback is queued — clearTimeout() cannot cancel a callback that has already
-       * entered the task queue, so the check here is the last line of defence.
+       * The timer callback re-checks autoReconnect before calling connect(). This
+       * closes a race where disconnect() is called after the timer fires but before
+       * this callback runs — clearTimeout() cannot stop a callback already queued.
        */
       private scheduleReconnect() {
           if (this.reconnectTimer !== null) return;
@@ -341,9 +343,6 @@ import WebSocket, { MessageEvent, CloseEvent, ErrorEvent } from "isomorphic-ws";
           console.log("Reconnecting in " + Math.round(delayMs) + "ms (attempt " + this.reconnectAttempt + ")");
           this.reconnectTimer = setTimeout(() => {
               this.reconnectTimer = null;
-              // Re-check autoReconnect here to handle the race where disconnect() is
-              // called after the timer fires but before this callback runs. clearTimeout()
-              // cannot stop a callback that is already in the task queue.
               if (this.autoReconnect) {
                   this.connect();
               }
@@ -365,7 +364,7 @@ import WebSocket, { MessageEvent, CloseEvent, ErrorEvent } from "isomorphic-ws";
       };
 
       /**
-       * Handles incoming WebSocket messages. Parses and processes custom messages if applicable.
+       * Handles incoming WebSocket messages.
        * @param event Raw WebSocket message data.
        */
       private onMessage = (event: MessageEvent): void => {
@@ -381,15 +380,10 @@ import WebSocket, { MessageEvent, CloseEvent, ErrorEvent } from "isomorphic-ws";
 
       /**
        * Closes the WebSocket connection and cancels any pending reconnect timer.
-       *
-       * Also resets reconnectAttempt to 0 so that if the caller later re-enables
-       * autoReconnect and calls connect() again, the back-off sequence starts from
-       * the initial delay rather than the large exponent accumulated during the
-       * previous failure run.
+       * Resets reconnectAttempt so a subsequent connect() starts back-off fresh.
        */
       public disconnect() {
           this.autoReconnect = false;
-          // Reset back-off counter so a subsequent connect()/re-enable starts fresh.
           this.reconnectAttempt = 0;
           if (this.reconnectTimer !== null) {
               clearTimeout(this.reconnectTimer);

--- a/src/client.ts
+++ b/src/client.ts
@@ -89,7 +89,7 @@ import WebSocket, { MessageEvent, CloseEvent, ErrorEvent } from "isomorphic-ws";
       /** Maximum back-off delay in milliseconds */
       private readonly maxReconnectDelay: number;
 
-      /** Current reconnect attempt count — used to compute exponential back-off */
+      /** Current reconnect attempt count - used to compute exponential back-off */
       private reconnectAttempt = 0;
 
       /** Pending setTimeout handle for the next reconnect attempt */
@@ -115,10 +115,14 @@ import WebSocket, { MessageEvent, CloseEvent, ErrorEvent } from "isomorphic-ws";
 
       /**
        * Monotonically-increasing id stamped onto each WebSocket at connect() time.
-       * close/error handlers compare their captured id against the current value to
-       * decide whether they belong to the live socket or a stale dying one. This
-       * prevents the double-reconnect triggered when both onError and onClose fire
-       * on the same closed socket.
+       *
+       * Every handler (onOpen, onClose, onError) captures this id in its closure
+       * and checks it against the current value before acting. This guarantees that
+       * a delayed or stale event from a superseded socket cannot:
+       *   - reset reconnectAttempt / start a duplicate ping loop (onOpen)
+       *   - falsely mark the client DISCONNECTED (onClose / onError)
+       *   - fire user callbacks against the wrong lifecycle
+       *   - trigger a double reconnect when both onError and onClose fire together
        */
       private connectionId = 0;
 
@@ -143,8 +147,17 @@ import WebSocket, { MessageEvent, CloseEvent, ErrorEvent } from "isomorphic-ws";
 
       /**
        * Establishes a WebSocket connection to the server.
+       *
+       * Cancels any pending back-off timer before opening a new socket, preventing
+       * a scheduled retry from firing after the caller has already reconnected manually.
        */
       public connect() {
+          // Cancel a pending back-off timer. Without this, calling connect() manually
+          // while a retry is scheduled causes the timer to fire and open a second socket.
+          if (this.reconnectTimer !== null) {
+              clearTimeout(this.reconnectTimer);
+              this.reconnectTimer = null;
+          }
           const id = ++this.connectionId;
           this.notifyStatusChange(ConnectionStatus.CONNECTING);
           this.ws = new WebSocket(this.host);
@@ -160,8 +173,15 @@ import WebSocket, { MessageEvent, CloseEvent, ErrorEvent } from "isomorphic-ws";
 
       /**
        * Handles WebSocket open event. Resets back-off, starts pinging, fires onConnect.
+       *
+       * Guards against stale open events from superseded sockets: a previous socket
+       * that was slow to connect could fire onOpen after connect() has already created
+       * a newer socket. Without the id check, that delayed open would reset
+       * reconnectAttempt, start a duplicate ping loop, and invoke onConnect against
+       * the wrong lifecycle.
        */
       private onOpen = (id: number) => {
+          if (id !== this.connectionId) return;
           this.reconnectAttempt = 0;
           this.ping();
           this.notifyStatusChange(ConnectionStatus.CONNECTED);
@@ -179,31 +199,38 @@ import WebSocket, { MessageEvent, CloseEvent, ErrorEvent } from "isomorphic-ws";
 
       /**
        * Handles WebSocket errors. Notifies caller and schedules a reconnect with back-off.
-       * @param id Connection id captured at connect() time.
-       * @param err Error object describing the issue.
+       *
+       * Guards with id === connectionId so that a stale error from a previous socket
+       * does not falsely mark the client DISCONNECTED or fire the user's onError
+       * callback while the current socket is healthy.
        */
       private onError = (id: number, err: ErrorEvent) => {
+          if (id !== this.connectionId) return;
           console.error("error", err);
           if (this.onUserError) {
               try { this.onUserError(this, err); } catch (e) { console.error("onError callback threw:", e); }
           }
-          if (this.autoReconnect && id === this.connectionId) {
+          this.notifyStatusChange(ConnectionStatus.DISCONNECTED);
+          if (this.autoReconnect) {
               this.scheduleReconnect();
           }
       };
 
       /**
        * Handles WebSocket close event. Notifies caller and schedules a reconnect with back-off.
-       * @param id Connection id captured at connect() time.
-       * @param message CloseEvent carrying the code and reason.
+       *
+       * Guards with id === connectionId so that a stale close from a previous socket
+       * does not falsely mark the client DISCONNECTED or fire the user's onClose
+       * callback while the current socket is healthy.
        */
       private onClose = (id: number, message: CloseEvent) => {
+          if (id !== this.connectionId) return;
           console.error("disconnected", "code", message.code, "reason", message.reason);
           this.notifyStatusChange(ConnectionStatus.DISCONNECTED);
           if (this.onUserClose) {
               try { this.onUserClose(this, message); } catch (e) { console.error("onClose callback threw:", e); }
           }
-          if (this.autoReconnect && id === this.connectionId) {
+          if (this.autoReconnect) {
               this.scheduleReconnect();
           }
       };
@@ -217,6 +244,10 @@ import WebSocket, { MessageEvent, CloseEvent, ErrorEvent } from "isomorphic-ws";
        * growth observed when a persistent network error (e.g. close code 1006) causes
        * connect() to be called in a tight loop, accumulating WebSocket objects faster
        * than the garbage collector can free them (see issue #38).
+       *
+       * The early-return on reconnectTimer prevents a second schedule if both onError
+       * and onClose fire on the same socket (both are now gated by id === connectionId
+       * so only one can win, but this guard is kept as defence-in-depth).
        */
       private scheduleReconnect() {
           if (this.reconnectTimer !== null) return;
@@ -263,7 +294,7 @@ import WebSocket, { MessageEvent, CloseEvent, ErrorEvent } from "isomorphic-ws";
       };
 
       /**
-       * Closes the WebSocket connection and cancels any pending reconnect.
+       * Closes the WebSocket connection and cancels any pending reconnect timer.
        */
       public disconnect() {
           this.autoReconnect = false;

--- a/src/client.ts
+++ b/src/client.ts
@@ -132,6 +132,20 @@ import WebSocket, { MessageEvent, CloseEvent, ErrorEvent } from "isomorphic-ws";
       private connectionId = 0;
 
       /**
+       * The id of the most recent socket that successfully reached the OPEN state.
+       * Set to the socket's id inside onOpen.
+       *
+       * Used by onClose to decide whether to emit DISCONNECTED and invoke onUserClose
+       * even when connectionId has already advanced (e.g. because onUserError or a
+       * manual caller invoked connect() before the close event fired). A socket that
+       * genuinely connected deserves a DISCONNECTED notification regardless of whether
+       * a replacement socket is already opening. A socket that was replaced before it
+       * ever opened does not — it never published a CONNECTED status so there is no
+       * paired DISCONNECTED to emit.
+       */
+      private lastConnectedId = -1;
+
+      /**
        * Constructs a new RealTimeDataClient instance.
        * @param args Configuration options for the client.
        */
@@ -161,8 +175,8 @@ import WebSocket, { MessageEvent, CloseEvent, ErrorEvent } from "isomorphic-ws";
        *
        * Ordering is critical: connectionId is incremented BEFORE the old socket is
        * closed. This ensures the old socket's onClose/onError handlers see a stale id
-       * and early-return, preventing spurious DISCONNECTED notifications or a rogue
-       * scheduleReconnect() call triggered by the deliberate close.
+       * and apply the correct notification logic (emit DISCONNECTED if the socket was
+       * ever connected, skip reconnect since a replacement is already starting).
        *
        * Also resets reconnectAttempt when it cancels a pending timer, so a manual
        * reconnect always starts the back-off sequence from the initial delay.
@@ -177,8 +191,8 @@ import WebSocket, { MessageEvent, CloseEvent, ErrorEvent } from "isomorphic-ws";
           }
 
           // Increment connectionId FIRST. Old socket handlers capture the previous id
-          // and will early-return on the id !== connectionId guard, so the deliberate
-          // ws.close() below does not emit a spurious DISCONNECTED or schedule a reconnect.
+          // and will use it to decide whether to emit notifications (based on
+          // lastConnectedId) vs. whether to schedule a reconnect (based on connectionId).
           const id = ++this.connectionId;
 
           // Close the previous socket if it is still open. Without this, each call to
@@ -201,17 +215,19 @@ import WebSocket, { MessageEvent, CloseEvent, ErrorEvent } from "isomorphic-ws";
       }
 
       /**
-       * Handles WebSocket open event. Resets back-off, starts pinging, fires onConnect.
+       * Handles WebSocket open event. Resets back-off, records lastConnectedId,
+       * starts pinging, and fires onConnect.
        *
-       * Guards against stale open events from superseded sockets: a previous socket
-       * that was slow to connect could fire onOpen after connect() has already created
-       * a newer socket. Without the id check, that delayed open would reset
-       * reconnectAttempt, start a duplicate ping loop, and invoke onConnect against
-       * the wrong lifecycle.
+       * Recording lastConnectedId here is the key: it marks this socket as having
+       * genuinely reached CONNECTED state, so that onClose can emit a paired
+       * DISCONNECTED notification even if connectionId has advanced by then.
+       *
+       * Guards against stale open events from superseded sockets.
        */
       private onOpen = (id: number) => {
           if (id !== this.connectionId) return;
           this.reconnectAttempt = 0;
+          this.lastConnectedId = id;
           this.ping();
           this.notifyStatusChange(ConnectionStatus.CONNECTED);
           if (this.onConnect) {
@@ -226,14 +242,9 @@ import WebSocket, { MessageEvent, CloseEvent, ErrorEvent } from "isomorphic-ws";
        * delay resolves. If connect() has superseded the socket in the meantime, the stale
        * pong chain's deferred ping() call is suppressed — preventing duplicate keepalive
        * traffic on the new connection from an old, dead ping/pong loop.
-       *
-       * @param id - Connection id captured when the pong handler was registered in connect().
        */
       private onPong = (id: number) => {
           delay(this.pingInterval).then(() => {
-              // Only continue the ping loop if this pong belongs to the current socket.
-              // Without this check, a superseded socket's pending delay resolves and calls
-              // ping() against this.ws (the new socket), duplicating keepalive traffic.
               if (id === this.connectionId) {
                   this.ping();
               }
@@ -264,28 +275,42 @@ import WebSocket, { MessageEvent, CloseEvent, ErrorEvent } from "isomorphic-ws";
 
       /**
        * Handles WebSocket close event. Emits DISCONNECTED status, fires onClose callback,
-       * and schedules a reconnect with exponential back-off if autoReconnect is enabled.
+       * and schedules a reconnect with exponential back-off when appropriate.
        *
-       * This is the single place that emits DISCONNECTED — onError intentionally does not
-       * emit it, since onClose always follows onError and emitting from both would produce
-       * duplicate status events for a single connection drop.
+       * Two independent questions are answered with two independent checks:
        *
-       * The connectionId is re-checked after the user's onClose callback because the
-       * callback itself may call connect() to reconnect immediately. If it did, connectionId
-       * has already advanced and we must not also call scheduleReconnect() — that would
-       * open a second socket on top of the one the callback just created.
+       * 1. Should we notify? (emit DISCONNECTED + invoke onUserClose)
+       *    Yes if this socket previously emitted CONNECTED (id === lastConnectedId).
+       *    This covers the case where connect() or disconnect() was called before the
+       *    close event fired — the socket genuinely was active and its close is
+       *    observable. A socket replaced before it ever opened is silently dropped
+       *    because no CONNECTED was ever published for it, so there is no paired
+       *    DISCONNECTED to emit.
+       *
+       * 2. Should we reconnect? (scheduleReconnect)
+       *    Only if no replacement socket has been started yet (id === connectionId)
+       *    AND autoReconnect is enabled AND the user's onClose callback did not
+       *    itself call connect() (second connectionId re-check after the callback).
        */
       private onClose = (id: number, message: CloseEvent) => {
-          if (id !== this.connectionId) return;
+          const wasConnected = id === this.lastConnectedId;
+          const isCurrent    = id === this.connectionId;
+
+          // Drop silently if this socket never reached CONNECTED and has already been
+          // superseded — nothing was published for it so there is nothing to unpublish.
+          if (!wasConnected && !isCurrent) return;
+
           console.error("disconnected", "code", message.code, "reason", message.reason);
           this.notifyStatusChange(ConnectionStatus.DISCONNECTED);
+
           if (this.onUserClose) {
               try { this.onUserClose(this, message); } catch (e) { console.error("onClose callback threw:", e); }
           }
-          // Re-check: the user's onClose callback may have called connect(), which
-          // increments connectionId. If so, skip scheduleReconnect() — a socket is
-          // already being opened and adding another reconnect would duplicate it.
-          if (this.autoReconnect && id === this.connectionId) {
+
+          // Re-check connectionId after the user callback: the callback may have called
+          // connect(), which increments connectionId. If it did, a socket is already
+          // opening and we must not also schedule a reconnect on top of it.
+          if (this.autoReconnect && isCurrent && id === this.connectionId) {
               this.scheduleReconnect();
           }
       };

--- a/src/client.ts
+++ b/src/client.ts
@@ -120,12 +120,13 @@ import WebSocket, { MessageEvent, CloseEvent, ErrorEvent } from "isomorphic-ws";
       /**
        * Monotonically-increasing id stamped onto each WebSocket at connect() time.
        *
-       * Every handler (onOpen, onClose, onError) captures this id in its closure
-       * and checks it against the current value before acting. This guarantees that
-       * a delayed or stale event from a superseded socket cannot:
+       * Every handler (onOpen, onClose, onError, onPong) captures this id in its
+       * closure and checks it against the current value before acting. This guarantees
+       * that a delayed or stale event from a superseded socket cannot:
        *   - reset reconnectAttempt / start a duplicate ping loop (onOpen)
        *   - falsely mark the client DISCONNECTED (onClose / onError)
        *   - fire user callbacks against the wrong lifecycle
+       *   - continue a keepalive ping chain from a dead connection (onPong)
        *   - trigger a double reconnect when both onError and onClose fire together
        */
       private connectionId = 0;
@@ -194,7 +195,7 @@ import WebSocket, { MessageEvent, CloseEvent, ErrorEvent } from "isomorphic-ws";
               this.ws.onmessage = this.onMessage;
               this.ws.onclose = (event: CloseEvent) => this.onClose(id, event);
               this.ws.onerror = (err: ErrorEvent) => this.onError(id, err);
-              this.ws.pong = this.onPong;
+              this.ws.pong = (data: Buffer) => this.onPong(id);
           }
           return this;
       }
@@ -219,10 +220,24 @@ import WebSocket, { MessageEvent, CloseEvent, ErrorEvent } from "isomorphic-ws";
       };
 
       /**
-       * Handles WebSocket pong event. Continues the ping cycle.
+       * Handles WebSocket pong event. Schedules the next ping after the configured interval.
+       *
+       * Captures connectionId at the moment the pong arrives and re-checks it when the
+       * delay resolves. If connect() has superseded the socket in the meantime, the stale
+       * pong chain's deferred ping() call is suppressed — preventing duplicate keepalive
+       * traffic on the new connection from an old, dead ping/pong loop.
+       *
+       * @param id - Connection id captured when the pong handler was registered in connect().
        */
-      private onPong = async () => {
-          delay(this.pingInterval).then(() => this.ping());
+      private onPong = (id: number) => {
+          delay(this.pingInterval).then(() => {
+              // Only continue the ping loop if this pong belongs to the current socket.
+              // Without this check, a superseded socket's pending delay resolves and calls
+              // ping() against this.ws (the new socket), duplicating keepalive traffic.
+              if (id === this.connectionId) {
+                  this.ping();
+              }
+          });
       };
 
       /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -152,22 +152,41 @@ import WebSocket, { MessageEvent, CloseEvent, ErrorEvent } from "isomorphic-ws";
       /**
        * Establishes a WebSocket connection to the server.
        *
-       * If called while a back-off timer is pending (e.g. the caller manually
-       * triggers a reconnect before the scheduled delay expires), the timer is
-       * cancelled and reconnectAttempt is reset so the next failure starts the
-       * back-off from the initial delay rather than an inherited large exponent.
+       * Safe to call at any time:
+       * - Cancels any pending back-off timer so a scheduled retry cannot open a
+       *   second socket alongside the one being created here.
+       * - Closes the previous WebSocket (if still open) to prevent file-descriptor
+       *   and connection-limit leaks when connect() is called while a socket is live.
+       *
+       * Ordering is critical: connectionId is incremented BEFORE the old socket is
+       * closed. This ensures the old socket's onClose/onError handlers see a stale id
+       * and early-return, preventing spurious DISCONNECTED notifications or a rogue
+       * scheduleReconnect() call triggered by the deliberate close.
+       *
+       * Also resets reconnectAttempt when it cancels a pending timer, so a manual
+       * reconnect always starts the back-off sequence from the initial delay.
        */
       public connect() {
-          // Cancel a pending back-off timer. Without this, calling connect() manually
-          // while a retry is scheduled causes the timer to fire and open a second socket.
-          // Also reset the attempt counter: a manual connect signals intent to start fresh,
-          // so the next auto-reconnect sequence should begin from the initial delay.
+          // Cancel any pending back-off retry.
           if (this.reconnectTimer !== null) {
               clearTimeout(this.reconnectTimer);
               this.reconnectTimer = null;
+              // Manual connect overrides the schedule — start back-off from scratch.
               this.reconnectAttempt = 0;
           }
+
+          // Increment connectionId FIRST. Old socket handlers capture the previous id
+          // and will early-return on the id !== connectionId guard, so the deliberate
+          // ws.close() below does not emit a spurious DISCONNECTED or schedule a reconnect.
           const id = ++this.connectionId;
+
+          // Close the previous socket if it is still open. Without this, each call to
+          // connect() while a socket is live abandons the old socket on the network,
+          // leaking file descriptors and browser/server connection slots.
+          if (this.ws && this.ws.readyState !== WebSocket.CLOSED && this.ws.readyState !== WebSocket.CLOSING) {
+              this.ws.close();
+          }
+
           this.notifyStatusChange(ConnectionStatus.CONNECTING);
           this.ws = new WebSocket(this.host);
           if (this.ws) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -198,11 +198,18 @@ import WebSocket, { MessageEvent, CloseEvent, ErrorEvent } from "isomorphic-ws";
       };
 
       /**
-       * Handles WebSocket errors. Notifies caller and schedules a reconnect with back-off.
+       * Handles WebSocket errors. Notifies the user onError callback.
+       *
+       * Does NOT emit notifyStatusChange(DISCONNECTED) here — onClose always fires
+       * after onError in the WebSocket lifecycle, so DISCONNECTED is emitted exactly
+       * once from onClose. Emitting it here too would cause onStatusChange to fire
+       * twice for a single connection drop.
+       *
+       * Does NOT call scheduleReconnect() here for the same reason: onClose will
+       * handle reconnection once, preventing a double-reconnect.
        *
        * Guards with id === connectionId so that a stale error from a previous socket
-       * does not falsely mark the client DISCONNECTED or fire the user's onError
-       * callback while the current socket is healthy.
+       * does not invoke the user's onError callback while the current socket is healthy.
        */
       private onError = (id: number, err: ErrorEvent) => {
           if (id !== this.connectionId) return;
@@ -210,18 +217,18 @@ import WebSocket, { MessageEvent, CloseEvent, ErrorEvent } from "isomorphic-ws";
           if (this.onUserError) {
               try { this.onUserError(this, err); } catch (e) { console.error("onError callback threw:", e); }
           }
-          this.notifyStatusChange(ConnectionStatus.DISCONNECTED);
-          if (this.autoReconnect) {
-              this.scheduleReconnect();
-          }
       };
 
       /**
-       * Handles WebSocket close event. Notifies caller and schedules a reconnect with back-off.
+       * Handles WebSocket close event. Emits DISCONNECTED status, fires onClose callback,
+       * and schedules a reconnect with exponential back-off if autoReconnect is enabled.
+       *
+       * This is the single place that emits DISCONNECTED — onError intentionally does not
+       * emit it, since onClose always follows onError and emitting from both would produce
+       * duplicate status events for a single connection drop.
        *
        * Guards with id === connectionId so that a stale close from a previous socket
-       * does not falsely mark the client DISCONNECTED or fire the user's onClose
-       * callback while the current socket is healthy.
+       * does not falsely mark the client DISCONNECTED while the current socket is healthy.
        */
       private onClose = (id: number, message: CloseEvent) => {
           if (id !== this.connectionId) return;
@@ -245,9 +252,10 @@ import WebSocket, { MessageEvent, CloseEvent, ErrorEvent } from "isomorphic-ws";
        * connect() to be called in a tight loop, accumulating WebSocket objects faster
        * than the garbage collector can free them (see issue #38).
        *
-       * The early-return on reconnectTimer prevents a second schedule if both onError
-       * and onClose fire on the same socket (both are now gated by id === connectionId
-       * so only one can win, but this guard is kept as defence-in-depth).
+       * The timer callback re-checks autoReconnect before calling connect(). This closes
+       * a race window where disconnect() is called after the timer has already fired and
+       * its callback is queued — clearTimeout() cannot cancel a callback that has already
+       * entered the task queue, so the check here is the last line of defence.
        */
       private scheduleReconnect() {
           if (this.reconnectTimer !== null) return;
@@ -260,7 +268,12 @@ import WebSocket, { MessageEvent, CloseEvent, ErrorEvent } from "isomorphic-ws";
           console.log("Reconnecting in " + Math.round(delayMs) + "ms (attempt " + this.reconnectAttempt + ")");
           this.reconnectTimer = setTimeout(() => {
               this.reconnectTimer = null;
-              this.connect();
+              // Re-check autoReconnect here to handle the race where disconnect() is
+              // called after the timer fires but before this callback runs. clearTimeout()
+              // cannot stop a callback that is already in the task queue.
+              if (this.autoReconnect) {
+                  this.connect();
+              }
           }, delayMs);
       }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,228 +1,327 @@
 import WebSocket, { MessageEvent, CloseEvent, ErrorEvent } from "isomorphic-ws";
-import { SubscriptionMessage, Message, ConnectionStatus } from "./model";
+    import { SubscriptionMessage, Message, ConnectionStatus } from "./model";
 
-const DEFAULT_HOST = "wss://ws-live-data.polymarket.com";
-const DEFAULT_PING_INTERVAL = 5000;
-
-/**
- * Interface representing the arguments for initializing a RealTimeDataClient.
- */
-export interface RealTimeDataClientArgs {
-    /**
-     * Optional callback function that is called when the client successfully connects.
-     * @param client - The instance of the RealTimeDataClient that has connected.
-     */
-    onConnect?: (client: RealTimeDataClient) => void;
+    const DEFAULT_HOST = "wss://ws-live-data.polymarket.com";
+    const DEFAULT_PING_INTERVAL = 5000;
+    const DEFAULT_RECONNECT_DELAY_MS = 1_000;
+    const MAX_RECONNECT_DELAY_MS = 30_000;
 
     /**
-     * Optional callback function that is called when the client receives a message.
-     * @param client - The instance of the RealTimeDataClient that received the message.
-     * @param message - The message received by the client.
-     */
-    onMessage?: (client: RealTimeDataClient, message: Message) => void;
+    * Interface representing the arguments for initializing a RealTimeDataClient.
+    */
+    export interface RealTimeDataClientArgs {
+      /**
+       * Optional callback function that is called when the client successfully connects.
+       * @param client - The instance of the RealTimeDataClient that has connected.
+       */
+      onConnect?: (client: RealTimeDataClient) => void;
 
-    /**
-     * Optional callback function that is called when the client receives a connection status update.
-     * @param status - The connection status of the client.
-     */
-    onStatusChange?: (status: ConnectionStatus) => void;
+      /**
+       * Optional callback function that is called when the client receives a message.
+       * @param client - The instance of the RealTimeDataClient that received the message.
+       * @param message - The message received by the client.
+       */
+      onMessage?: (client: RealTimeDataClient, message: Message) => void;
 
-    /**
-     * Optional host address to connect to.
-     */
-    host?: string;
+      /**
+       * Optional callback function that is called when the connection is closed.
+       * Receives the close event so callers can inspect the code and reason.
+       * @param client - The instance of the RealTimeDataClient that disconnected.
+       * @param event - The WebSocket CloseEvent containing code and reason.
+       */
+      onClose?: (client: RealTimeDataClient, event: CloseEvent) => void;
 
-    /**
-     * Optional interval in milliseconds for sending ping messages to keep the connection alive.
-     */
-    pingInterval?: number;
+      /**
+       * Optional callback function that is called when a WebSocket error occurs.
+       * @param client - The instance of the RealTimeDataClient that errored.
+       * @param error - The ErrorEvent describing the error.
+       */
+      onError?: (client: RealTimeDataClient, error: ErrorEvent) => void;
 
-    /**
-     * Optional flag to enable or disable automatic reconnection when the connection is lost.
-     */
-    autoReconnect?: boolean;
-}
+      /**
+       * Optional callback function that is called when the client receives a connection status update.
+       * @param status - The connection status of the client.
+       */
+      onStatusChange?: (status: ConnectionStatus) => void;
 
-/**
- * A client for managing real-time WebSocket connections, handling messages, subscriptions,
- * and automatic reconnections.
- */
-export class RealTimeDataClient {
-    /** WebSocket server host URL */
-    private readonly host: string;
+      /** Optional host address to connect to. */
+      host?: string;
 
-    /** Interval (in milliseconds) for sending ping messages */
-    private readonly pingInterval: number;
+      /** Optional interval in milliseconds for sending ping messages to keep the connection alive. */
+      pingInterval?: number;
 
-    /** Determines whether the client should automatically reconnect on disconnection */
-    private autoReconnect: boolean;
+      /**
+       * Optional flag to enable or disable automatic reconnection when the connection is lost.
+       * Defaults to true.
+       */
+      autoReconnect?: boolean;
 
-    /** Callback function executed when the connection is established */
-    private readonly onConnect?: (client: RealTimeDataClient) => void;
+      /**
+       * Initial reconnect delay in milliseconds. Doubles on each failed attempt (exponential
+       * back-off) up to maxReconnectDelay. Defaults to 1000 ms.
+       */
+      reconnectDelay?: number;
 
-    /** Callback function executed when a custom message is received */
-    private readonly onCustomMessage?: (client: RealTimeDataClient, message: Message) => void;
-
-    /** Callback function executed on a connection status update */
-    private readonly onStatusChange?: (status: ConnectionStatus) => void;
-
-    /** WebSocket instance */
-    private ws!: WebSocket;
-
-    /**
-     * Constructs a new RealTimeDataClient instance.
-     * @param args Configuration options for the client.
-     */
-    constructor(args?: RealTimeDataClientArgs) {
-        this.host = args!.host || DEFAULT_HOST;
-        this.pingInterval = args!.pingInterval || DEFAULT_PING_INTERVAL;
-        this.autoReconnect = args!.autoReconnect || true;
-        this.onCustomMessage = args!.onMessage;
-        this.onConnect = args!.onConnect;
-        this.onStatusChange = args!.onStatusChange;
+      /**
+       * Maximum reconnect delay in milliseconds. Caps the exponential back-off growth.
+       * Defaults to 30 000 ms (30 s).
+       */
+      maxReconnectDelay?: number;
     }
 
     /**
-     * Establishes a WebSocket connection to the server.
-     */
-    public connect() {
-        this.notifyStatusChange(ConnectionStatus.CONNECTING);
-        this.ws = new WebSocket(this.host);
-        if (this.ws) {
-            this.ws.onopen = this.onOpen;
-            this.ws.onmessage = this.onMessage;
-            this.ws.onclose = this.onClose;
-            this.ws.onerror = this.onError;
-            this.ws.pong = this.onPong;
-        }
-        return this;
+    * A client for managing real-time WebSocket connections, handling messages, subscriptions,
+    * and automatic reconnections.
+    */
+    export class RealTimeDataClient {
+      /** WebSocket server host URL */
+      private readonly host: string;
+
+      /** Interval (in milliseconds) for sending ping messages */
+      private readonly pingInterval: number;
+
+      /** Determines whether the client should automatically reconnect on disconnection */
+      private autoReconnect: boolean;
+
+      /** Initial back-off delay in milliseconds */
+      private readonly reconnectDelayBase: number;
+
+      /** Maximum back-off delay in milliseconds */
+      private readonly maxReconnectDelay: number;
+
+      /** Current reconnect attempt count — used to compute exponential back-off */
+      private reconnectAttempt = 0;
+
+      /** Pending setTimeout handle for the next reconnect attempt */
+      private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
+      /** Callback function executed when the connection is established */
+      private readonly onConnect?: (client: RealTimeDataClient) => void;
+
+      /** Callback function executed when a custom message is received */
+      private readonly onCustomMessage?: (client: RealTimeDataClient, message: Message) => void;
+
+      /** Callback function executed on a connection status update */
+      private readonly onStatusChange?: (status: ConnectionStatus) => void;
+
+      /** User-provided callback executed when the connection closes */
+      private readonly onUserClose?: (client: RealTimeDataClient, event: CloseEvent) => void;
+
+      /** User-provided callback executed when a WebSocket error occurs */
+      private readonly onUserError?: (client: RealTimeDataClient, error: ErrorEvent) => void;
+
+      /** WebSocket instance */
+      private ws!: WebSocket;
+
+      /**
+       * Monotonically-increasing id stamped onto each WebSocket at connect() time.
+       * close/error handlers compare their captured id against the current value to
+       * decide whether they belong to the live socket or a stale dying one. This
+       * prevents the double-reconnect triggered when both onError and onClose fire
+       * on the same closed socket.
+       */
+      private connectionId = 0;
+
+      /**
+       * Constructs a new RealTimeDataClient instance.
+       * @param args Configuration options for the client.
+       */
+      constructor(args?: RealTimeDataClientArgs) {
+          this.host = args?.host || DEFAULT_HOST;
+          this.pingInterval = args?.pingInterval || DEFAULT_PING_INTERVAL;
+          // Fix: use ?? instead of || so that explicitly passing false is honoured.
+          // The previous || true treated false as falsy and always enabled autoReconnect.
+          this.autoReconnect = args?.autoReconnect ?? true;
+          this.reconnectDelayBase = args?.reconnectDelay ?? DEFAULT_RECONNECT_DELAY_MS;
+          this.maxReconnectDelay = args?.maxReconnectDelay ?? MAX_RECONNECT_DELAY_MS;
+          this.onCustomMessage = args?.onMessage;
+          this.onConnect = args?.onConnect;
+          this.onStatusChange = args?.onStatusChange;
+          this.onUserClose = args?.onClose;
+          this.onUserError = args?.onError;
+      }
+
+      /**
+       * Establishes a WebSocket connection to the server.
+       */
+      public connect() {
+          const id = ++this.connectionId;
+          this.notifyStatusChange(ConnectionStatus.CONNECTING);
+          this.ws = new WebSocket(this.host);
+          if (this.ws) {
+              this.ws.onopen = () => this.onOpen(id);
+              this.ws.onmessage = this.onMessage;
+              this.ws.onclose = (event: CloseEvent) => this.onClose(id, event);
+              this.ws.onerror = (err: ErrorEvent) => this.onError(id, err);
+              this.ws.pong = this.onPong;
+          }
+          return this;
+      }
+
+      /**
+       * Handles WebSocket open event. Resets back-off, starts pinging, fires onConnect.
+       */
+      private onOpen = (id: number) => {
+          this.reconnectAttempt = 0;
+          this.ping();
+          this.notifyStatusChange(ConnectionStatus.CONNECTED);
+          if (this.onConnect) {
+              this.onConnect(this);
+          }
+      };
+
+      /**
+       * Handles WebSocket pong event. Continues the ping cycle.
+       */
+      private onPong = async () => {
+          delay(this.pingInterval).then(() => this.ping());
+      };
+
+      /**
+       * Handles WebSocket errors. Notifies caller and schedules a reconnect with back-off.
+       * @param id Connection id captured at connect() time.
+       * @param err Error object describing the issue.
+       */
+      private onError = (id: number, err: ErrorEvent) => {
+          console.error("error", err);
+          if (this.onUserError) {
+              try { this.onUserError(this, err); } catch (e) { console.error("onError callback threw:", e); }
+          }
+          if (this.autoReconnect && id === this.connectionId) {
+              this.scheduleReconnect();
+          }
+      };
+
+      /**
+       * Handles WebSocket close event. Notifies caller and schedules a reconnect with back-off.
+       * @param id Connection id captured at connect() time.
+       * @param message CloseEvent carrying the code and reason.
+       */
+      private onClose = (id: number, message: CloseEvent) => {
+          console.error("disconnected", "code", message.code, "reason", message.reason);
+          this.notifyStatusChange(ConnectionStatus.DISCONNECTED);
+          if (this.onUserClose) {
+              try { this.onUserClose(this, message); } catch (e) { console.error("onClose callback threw:", e); }
+          }
+          if (this.autoReconnect && id === this.connectionId) {
+              this.scheduleReconnect();
+          }
+      };
+
+      /**
+       * Schedules a reconnect attempt using exponential back-off with jitter.
+       *
+       *   delay = min(reconnectDelay x 2^attempt, maxReconnectDelay) + rand(0..1000) ms
+       *
+       * Back-off prevents thundering herd on server restarts and stops the heap-memory
+       * growth observed when a persistent network error (e.g. close code 1006) causes
+       * connect() to be called in a tight loop, accumulating WebSocket objects faster
+       * than the garbage collector can free them (see issue #38).
+       */
+      private scheduleReconnect() {
+          if (this.reconnectTimer !== null) return;
+          const delayMs =
+              Math.min(
+                  this.reconnectDelayBase * Math.pow(2, this.reconnectAttempt),
+                  this.maxReconnectDelay,
+              ) + Math.random() * 1_000;
+          this.reconnectAttempt++;
+          console.log("Reconnecting in " + Math.round(delayMs) + "ms (attempt " + this.reconnectAttempt + ")");
+          this.reconnectTimer = setTimeout(() => {
+              this.reconnectTimer = null;
+              this.connect();
+          }, delayMs);
+      }
+
+      /**
+       * Sends a ping message to keep the connection alive.
+       */
+      private ping = async () => {
+          if (this.ws.readyState !== WebSocket.OPEN) {
+              return console.warn("Socket not open. Ready state is:", this.ws.readyState);
+          }
+          this.ws.send("ping", (err: Error | undefined) => {
+              if (err) {
+                  console.error("ping error", err);
+              }
+          });
+      };
+
+      /**
+       * Handles incoming WebSocket messages. Parses and processes custom messages if applicable.
+       * @param event Raw WebSocket message data.
+       */
+      private onMessage = (event: MessageEvent): void => {
+          if (typeof event.data === "string" && event.data.length > 0) {
+              if (this.onCustomMessage && event.data.includes("payload")) {
+                  const message = JSON.parse(event.data);
+                  this.onCustomMessage(this, message as Message);
+              } else {
+                  console.log("onMessage error", { event });
+              }
+          }
+      };
+
+      /**
+       * Closes the WebSocket connection and cancels any pending reconnect.
+       */
+      public disconnect() {
+          this.autoReconnect = false;
+          if (this.reconnectTimer !== null) {
+              clearTimeout(this.reconnectTimer);
+              this.reconnectTimer = null;
+          }
+          if (this.ws && this.ws.readyState !== WebSocket.CLOSED && this.ws.readyState !== WebSocket.CLOSING) {
+              this.ws.close();
+          }
+      }
+
+      /**
+       * Subscribes to a data stream by sending a subscription message.
+       * @param msg Subscription request message.
+       */
+      public subscribe(msg: SubscriptionMessage) {
+          if (this.ws.readyState !== WebSocket.OPEN) {
+              return console.warn("Socket not open. Ready state is:", this.ws.readyState);
+          }
+          this.ws.send(JSON.stringify({ action: "subscribe", ...msg }), (err?: Error) => {
+              if (err) {
+                  console.error("subscribe error", err);
+                  this.ws.close();
+              }
+          });
+      }
+
+      /**
+       * Unsubscribes from a data stream by sending an unsubscription message.
+       * @param msg Unsubscription request message.
+       */
+      public unsubscribe(msg: SubscriptionMessage) {
+          if (this.ws.readyState !== WebSocket.OPEN) {
+              return console.warn("Socket not open. Ready state is:", this.ws.readyState);
+          }
+          console.log("unsubscribing", { msg });
+          this.ws.send(JSON.stringify({ action: "unsubscribe", ...msg }), (err?: Error) => {
+              if (err) {
+                  console.error("unsubscribe error", err);
+                  this.ws.close();
+              }
+          });
+      }
+
+      /**
+       * Callback for connection status changes.
+       * @param status status of the connection
+       */
+      private notifyStatusChange(status: ConnectionStatus) {
+          if (this.onStatusChange) {
+              this.onStatusChange(status);
+          }
+          return status;
+      }
     }
 
-    /**
-     * Handles WebSocket 'open' event. Executes the `onConnect` callback and starts pinging.
-     */
-    private onOpen = async () => {
-        this.ping();
-        this.notifyStatusChange(ConnectionStatus.CONNECTED);
-        if (this.onConnect) {
-            this.onConnect(this);
-        }
-    };
-
-    /**
-     * Handles WebSocket 'pong' event. Continues the ping cycle.
-     */
-    private onPong = async () => {
-        delay(this.pingInterval).then(() => this.ping());
-    };
-
-    /**
-     * Handles WebSocket errors. Logs the error and attempts reconnection if `autoReconnect` is enabled.
-     * @param err Error object describing the issue.
-     */
-    private onError = async (err: ErrorEvent) => {
-        console.error("error", err);
-        if (this.autoReconnect) {
-            this.connect();
-        }
-    };
-
-    /**
-     * Handles WebSocket 'close' event. Logs the disconnect reason and attempts reconnection if `autoReconnect` is enabled.
-     * @param code Close event code.
-     * @param reason Buffer containing the reason for closure.
-     */
-    private onClose = async (message: CloseEvent) => {
-        console.error("disconnected", "code", message.code, "reason", message.reason);
-        this.notifyStatusChange(ConnectionStatus.DISCONNECTED);
-        if (this.autoReconnect) {
-            this.connect();
-        }
-    };
-
-    /**
-     * Sends a ping message to keep the connection alive.
-     */
-    private ping = async () => {
-        if (this.ws.readyState !== WebSocket.OPEN) {
-            return console.warn("Socket not open. Ready state is:", this.ws.readyState);
-        }
-
-        this.ws.send("ping", (err: Error | undefined) => {
-            if (err) {
-                console.error("ping error", err);
-            }
-        });
-    };
-
-    /**
-     * Handles incoming WebSocket messages. Parses and processes custom messages if applicable.
-     * @param event Raw WebSocket message data.
-     */
-    private onMessage = (event: MessageEvent): void => {
-        if (typeof event.data === "string" && event.data.length > 0) {
-            if (this.onCustomMessage && event.data.includes("payload")) {
-                const message = JSON.parse(event.data);
-                this.onCustomMessage(this, message as Message);
-            } else {
-                console.log("onMessage error", { event });
-            }
-        }
-    };
-
-    /**
-     * Closes the WebSocket connection.
-     */
-    public disconnect() {
-        this.autoReconnect = false;
-        this.ws.close();
+    function delay(ms: number) {
+      return new Promise(resolve => setTimeout(resolve, ms));
     }
-
-    /**
-     * Subscribes to a data stream by sending a subscription message.
-     * @param msg Subscription request message.
-     */
-    public subscribe(msg: SubscriptionMessage) {
-        if (this.ws.readyState !== WebSocket.OPEN) {
-            return console.warn("Socket not open. Ready state is:", this.ws.readyState);
-        }
-        this.ws.send(JSON.stringify({ action: "subscribe", ...msg }), (err?: Error) => {
-            if (err) {
-                console.error("subscribe error", err);
-                this.ws.close();
-            }
-        });
-    }
-
-    /**
-     * Unsubscribes from a data stream by sending an unsubscription message.
-     * @param msg Unsubscription request message.
-     */
-    public unsubscribe(msg: SubscriptionMessage) {
-        if (this.ws.readyState !== WebSocket.OPEN) {
-            return console.warn("Socket not open. Ready state is:", this.ws.readyState);
-        }
-        console.log("unsubscribing", { msg });
-        this.ws.send(JSON.stringify({ action: "unsubscribe", ...msg }), (err?: Error) => {
-            if (err) {
-                console.error("unsubscribe error", err);
-                this.ws.close();
-            }
-        });
-    }
-
-    /**
-     * Callback for connection status changes
-     * @param status status of the connection
-     */
-    private notifyStatusChange(status: ConnectionStatus) {
-        if (this.onStatusChange) {
-            this.onStatusChange(status);
-        }
-        return status;
-    }
-}
-
-function delay(ms: number) {
-    return new Promise(resolve => setTimeout(resolve, ms));
-}
+    

--- a/src/client.ts
+++ b/src/client.ts
@@ -89,7 +89,11 @@ import WebSocket, { MessageEvent, CloseEvent, ErrorEvent } from "isomorphic-ws";
       /** Maximum back-off delay in milliseconds */
       private readonly maxReconnectDelay: number;
 
-      /** Current reconnect attempt count - used to compute exponential back-off */
+      /**
+       * Current reconnect attempt count — used to compute exponential back-off.
+       * Reset to 0 on successful open, on disconnect(), and when connect() cancels
+       * a pending timer (i.e. a manual reconnect that overrides the back-off schedule).
+       */
       private reconnectAttempt = 0;
 
       /** Pending setTimeout handle for the next reconnect attempt */
@@ -148,15 +152,20 @@ import WebSocket, { MessageEvent, CloseEvent, ErrorEvent } from "isomorphic-ws";
       /**
        * Establishes a WebSocket connection to the server.
        *
-       * Cancels any pending back-off timer before opening a new socket, preventing
-       * a scheduled retry from firing after the caller has already reconnected manually.
+       * If called while a back-off timer is pending (e.g. the caller manually
+       * triggers a reconnect before the scheduled delay expires), the timer is
+       * cancelled and reconnectAttempt is reset so the next failure starts the
+       * back-off from the initial delay rather than an inherited large exponent.
        */
       public connect() {
           // Cancel a pending back-off timer. Without this, calling connect() manually
           // while a retry is scheduled causes the timer to fire and open a second socket.
+          // Also reset the attempt counter: a manual connect signals intent to start fresh,
+          // so the next auto-reconnect sequence should begin from the initial delay.
           if (this.reconnectTimer !== null) {
               clearTimeout(this.reconnectTimer);
               this.reconnectTimer = null;
+              this.reconnectAttempt = 0;
           }
           const id = ++this.connectionId;
           this.notifyStatusChange(ConnectionStatus.CONNECTING);
@@ -227,8 +236,10 @@ import WebSocket, { MessageEvent, CloseEvent, ErrorEvent } from "isomorphic-ws";
        * emit it, since onClose always follows onError and emitting from both would produce
        * duplicate status events for a single connection drop.
        *
-       * Guards with id === connectionId so that a stale close from a previous socket
-       * does not falsely mark the client DISCONNECTED while the current socket is healthy.
+       * The connectionId is re-checked after the user's onClose callback because the
+       * callback itself may call connect() to reconnect immediately. If it did, connectionId
+       * has already advanced and we must not also call scheduleReconnect() — that would
+       * open a second socket on top of the one the callback just created.
        */
       private onClose = (id: number, message: CloseEvent) => {
           if (id !== this.connectionId) return;
@@ -237,7 +248,10 @@ import WebSocket, { MessageEvent, CloseEvent, ErrorEvent } from "isomorphic-ws";
           if (this.onUserClose) {
               try { this.onUserClose(this, message); } catch (e) { console.error("onClose callback threw:", e); }
           }
-          if (this.autoReconnect) {
+          // Re-check: the user's onClose callback may have called connect(), which
+          // increments connectionId. If so, skip scheduleReconnect() — a socket is
+          // already being opened and adding another reconnect would duplicate it.
+          if (this.autoReconnect && id === this.connectionId) {
               this.scheduleReconnect();
           }
       };
@@ -308,9 +322,16 @@ import WebSocket, { MessageEvent, CloseEvent, ErrorEvent } from "isomorphic-ws";
 
       /**
        * Closes the WebSocket connection and cancels any pending reconnect timer.
+       *
+       * Also resets reconnectAttempt to 0 so that if the caller later re-enables
+       * autoReconnect and calls connect() again, the back-off sequence starts from
+       * the initial delay rather than the large exponent accumulated during the
+       * previous failure run.
        */
       public disconnect() {
           this.autoReconnect = false;
+          // Reset back-off counter so a subsequent connect()/re-enable starts fresh.
+          this.reconnectAttempt = 0;
           if (this.reconnectTimer !== null) {
               clearTimeout(this.reconnectTimer);
               this.reconnectTimer = null;


### PR DESCRIPTION
## Summary

    Fixes three related bugs in `RealTimeDataClient` and adds two new features. All changes are in `src/client.ts`.

    ---

    ### Bug 1 — `autoReconnect: false` silently ignored (fixes #43)

    ```ts
    // before (broken) — false is falsy, so this always evaluates to true
    this.autoReconnect = args!.autoReconnect || true;

    // after
    this.autoReconnect = args?.autoReconnect ?? true;
    ```

    ---

    ### Bug 2 — No `onClose` / `onError` callbacks (fixes #43)

    Added both to `RealTimeDataClientArgs` and wired them into the handlers with a try/catch guard so a throwing callback cannot crash the client.

    ```ts
    const client = new RealTimeDataClient({
      onClose: (client, event) => console.log("closed:", event.code, event.reason),
      onError: (client, err)   => console.error("ws error:", err),
    });
    ```

    ---

    ### Bug 3 — Heap OOM on persistent network errors (fixes #38)

    **Root cause:** when the socket closes with code 1006 (abnormal close — e.g. dropped mobile network), the previous code called `this.connect()` synchronously inside both `onError` and `onClose`. On a sustained outage this creates a tight loop: each failed attempt fires both handlers, both call `connect()`, two new `WebSocket` objects are allocated, and their internal buffers accumulate in the heap faster than GC can reclaim them.

    **Fix:** replaced the immediate `connect()` with `scheduleReconnect()`, which uses **exponential back-off with ±1 s jitter**:

    ```
    delay = min(reconnectDelay × 2^attempt, maxReconnectDelay) + rand(0..1000) ms
    ```

    Defaults: **1 s** initial, **30 s** cap — both configurable:

    ```ts
    const client = new RealTimeDataClient({
      reconnectDelay:    500,    // first retry after 500 ms
      maxReconnectDelay: 60_000, // cap at 60 s
    });
    ```

    ---

    ### Bonus fixes

    | Fix | Detail |
    |---|---|
    | **Double-reconnect prevention** | Added `connectionId` counter stamped at `connect()` time. `onError` and `onClose` handlers compare their captured id against the current value — only the handler that matches schedules a reconnect. Prevents two concurrent reconnect attempts when both fire on the same dead socket. |
    | **`disconnect()` improvements** | Clears the pending reconnect timer on `disconnect()` (so a scheduled retry doesn't fire after the caller intentionally disconnects). Also guards against calling `ws.close()` on an already-CLOSED or CLOSING socket. |
    | **Optional chaining in constructor** | Changed `args!` → `args?` throughout the constructor so `new RealTimeDataClient()` with no arguments no longer throws a runtime error on the non-null assertion. |

    ---

    ### Relation to open PRs

    - **#44 / #45** — also fix the `autoReconnect` bug and add `onClose`/`onError` callbacks. This PR duplicates those two fixes but adds the exponential back-off (#38) which neither PR includes. Happy to rebase on top of whichever PR merges first and drop the duplicate hunks if that's easier to review.

    ---

    ### Testing

    Manually tested against `wss://ws-live-data.polymarket.com` with simulated network drops (disabled NIC mid-stream). Confirmed:
    - Reconnect attempts respect the back-off schedule
    - Heap memory stays stable under sustained 1006 errors (no OOM)
    - `autoReconnect: false` correctly prevents reconnection
    - `disconnect()` cancels a pending retry timer

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core WebSocket connection lifecycle and status semantics; behavior shifts for consumers relying on immediate reconnect or prior status ordering, though scope is limited to one client module.
> 
> **Overview**
> Overhauls **`RealTimeDataClient`** reconnection and lifecycle handling in `src/client.ts`.
> 
> **Reconnect behavior:** Immediate `connect()` on error/close is replaced with **`scheduleReconnect()`** using exponential backoff (configurable `reconnectDelay` / `maxReconnectDelay`) plus jitter, addressing tight reconnect loops and heap growth on sustained outages.
> 
> **API & bugs:** Adds optional **`onClose`** and **`onError`** callbacks (with try/catch). Fixes **`autoReconnect: false`** by using `??` instead of `|| true`. Constructor uses optional chaining so `new RealTimeDataClient()` without args is safe.
> 
> **Concurrency / state:** Introduces **`connectionId`** and **`lastConnectedId`** so stale socket events cannot double-reconnect, corrupt status (`CONNECTING` → `DISCONNECTED` without `CONNECTED`), or keep ping chains alive. **`onClose`** alone schedules reconnect and emits `DISCONNECTED` only when the socket had reached `CONNECTED`. **`connect()`** cancels pending timers, closes the previous socket, and resets backoff when overriding a scheduled retry; **`disconnect()`** clears timers and avoids closing already-closed sockets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33052dcb53c4b8734ef532769bcc3bb45cf283ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->